### PR TITLE
Rename "load" component type to "consumption"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+Renamed the `"load"` component type to `"consumption"` for clarity.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+If your code references `"load"` as a component type, update it to `"consumption"`.
 
 ## New Features
 

--- a/src/frequenz/lib/notebooks/config.py
+++ b/src/frequenz/lib/notebooks/config.py
@@ -7,7 +7,7 @@ import tomllib
 from dataclasses import dataclass
 from typing import Any, Literal, cast, get_args
 
-ComponentType = Literal["grid", "pv", "battery", "load", "chp"]
+ComponentType = Literal["grid", "pv", "battery", "consumption", "chp"]
 """Valid component types."""
 
 ComponentCategory = Literal["meter", "inverter", "component"]


### PR DESCRIPTION
Updated `ComponentType` to replace "load" with "consumption" for clarity.