### PR TITLE
Allow missing ctype field in microgrid config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@ Renamed the `"load"` component type to `"consumption"` for clarity.
 
 ## Upgrading
 
-If your code references `"load"` as a component type, update it to `"consumption"`.
+- If your code references `"load"` as a component type, update it to `"consumption"`.
+- Made the `MicrogridConfig` reader tolerant to missing `ctype` fields, allowing collection of incomplete microgrid configs.
 
 ## New Features
 

--- a/src/frequenz/lib/notebooks/config.py
+++ b/src/frequenz/lib/notebooks/config.py
@@ -172,7 +172,7 @@ class MicrogridConfig:
 
         self._component_types_cfg = {
             ctype: ComponentTypeConfig(component_type=cast(ComponentType, ctype), **cfg)
-            for ctype, cfg in config_dict["ctype"].items()
+            for ctype, cfg in config_dict.get("ctype", {}).items()
             if ComponentTypeConfig.is_valid_type(ctype)
         }
 


### PR DESCRIPTION
Updated `MicrogridConfig` to handle missing `ctype` fields, allowing collection of incomplete microgrid configs.