### PR TITLE
Update reporting and weather clients

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,9 +10,7 @@
 
 ## New Features
 
-- Improved MIME type detection for email attachments, with a fallback for unknown file types.
-- Introduced a new alerts module for generating and formatting alert emails.
-- Added basic Alert and Solar Maintenance notebooks with instructions in English and German. These notebooks are aimed for running in a Deepnote project as they contain Deepnote related UI elements but they can also run in a common jupyter environment if the Deepnote UI elements are discarded.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+The `frequenz-api-weather` package has been removed in favor of `frequenz-client-weather` because the required methods have been moved over to the latter library.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The minimum required version of `frequenz-client-reporting` is now `v0.14.0`.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "python-dotenv >= 0.21.0, < 1.1.0",
   "toml >= 0.10.2, < 0.11.0",
   "frequenz-client-reporting >= 0.14.0, < 0.15.0",
-  "frequenz-api-weather >= 0.9.0, < 0.10.0",
+  "frequenz-client-weather >= 0.1.0, < 0.2.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "pvlib >= 0.11.0, < 0.12.0",
   "python-dotenv >= 0.21.0, < 1.1.0",
   "toml >= 0.10.2, < 0.11.0",
-  "frequenz-client-reporting >= 0.13.0, < 0.14.0",
+  "frequenz-client-reporting >= 0.14.0, < 0.15.0",
   "frequenz-api-weather >= 0.9.0, < 0.10.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
- Bumps reporting client to minimum `v0.14.0`.
- Replaces `frequenz-api-weather` with the new library `frequenz-client-weather`.