### PR TITLE
Avoid importing CSSDict from Pandas to prevent Jinja2 conflicts

### DIFF
--- a/src/frequenz/lib/notebooks/alerts/__init__.py
+++ b/src/frequenz/lib/notebooks/alerts/__init__.py
@@ -1,10 +1,10 @@
-"""
-Alerts module for handling alert-related logic.
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
-This includes email generation, processing, and formatting. This module
-provides utilities to generate alert summaries, format alert details, and
-create structured HTML emails.
+"""Initialise the alerts module."""
 
-Modules:
-    - alert_email: Functions to generate alert-related emails.
-"""
+from . import alert_email
+
+__all__ = [
+    "alert_email",
+]

--- a/src/frequenz/lib/notebooks/alerts/alert_email.py
+++ b/src/frequenz/lib/notebooks/alerts/alert_email.py
@@ -56,11 +56,10 @@ print(email_html)
 """
 import html
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pandas as pd
 from pandas import Series
-from pandas.io.formats.style_render import CSSDict
 
 EMAIL_CSS = """
 <style>
@@ -273,16 +272,24 @@ def generate_alert_table(
     }
 
     # general table styling
-    table_styles: list[CSSDict] = [
-        {
-            "selector": "th",
-            "props": [("background-color", "#f4f4f4"), ("font-weight", "bold")],
-        },
-        {
-            "selector": "td, th",
-            "props": [("border", "1px solid #ddd"), ("padding", "8px")],
-        },
-    ]
+    # We use cast(Any, ...) here to bypass mypy's strict type checking on .set_table_styles().
+    # Pandas internally expects CSSDict, which we want to avoid importing to prevent
+    # unnecessary dependencies (like with Jinja2 library).
+    # Since the structure is guaranteed to be correct for Pandas at runtime, using Any
+    # ensures type flexibility while avoiding compatibility issues with future Pandas versions.
+    table_styles = cast(
+        Any,
+        [
+            {
+                "selector": "th",
+                "props": [("background-color", "#f4f4f4"), ("font-weight", "bold")],
+            },
+            {
+                "selector": "td, th",
+                "props": [("border", "1px solid #ddd"), ("padding", "8px")],
+            },
+        ],
+    )
 
     # apply severity color to entire rows
     styled_table = (


### PR DESCRIPTION
Replaced the import of `CSSDict` with `cast(Any, ...)` to avoid dependency conflicts with `Jinja2` in `Deepnote`. This maintains compatibility with `pandas.Styler.set_table_styles()` while removing unnecessary imports. No functional changes.