### PR TITLE
Guard against non-scalar timestamps in alert records

### DIFF
--- a/src/frequenz/lib/notebooks/alerts/alert_email.py
+++ b/src/frequenz/lib/notebooks/alerts/alert_email.py
@@ -72,6 +72,7 @@ import plotly.colors as pc
 import plotly.graph_objects as go
 import plotly.io as pio
 from pandas import Series
+from pandas.api.types import is_scalar
 
 _log = logging.getLogger(__name__)
 
@@ -248,15 +249,17 @@ def _format_timedelta(delta: timedelta) -> str:
     return " ".join(parts) if parts else "0s"
 
 
-def _parse_and_localize_timestamp(timestamp: Any) -> pd.Timestamp:
+def _parse_and_localize_timestamp(timestamp: Any) -> pd.Timestamp | None:
     """Parse a timestamp, coerce errors to NaT, and localize to UTC if naive.
 
     Args:
         timestamp: The timestamp value to process.
 
     Returns:
-        A timezone-aware Pandas Timestamp, or NaT if parsing fails.
+        A timezone-aware Pandas Timestamp, or None if the input is not a scalar.
     """
+    if not is_scalar(timestamp):
+        return None
     parsed_time = pd.to_datetime(timestamp, errors="coerce")
     if pd.notna(parsed_time) and parsed_time.tz is None:
         return pd.Timestamp(parsed_time.tz_localize("UTC"))

--- a/tests/test_alert_email.py
+++ b/tests/test_alert_email.py
@@ -2,12 +2,14 @@
 # Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the frequenz.lib.notebooks.alerts module."""
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from pandas.api.types import is_scalar
 
 from frequenz.lib.notebooks.alerts.alert_email import (
     AlertPlotType,
@@ -15,6 +17,7 @@ from frequenz.lib.notebooks.alerts.alert_email import (
     ImageExportFormat,
     _coerce_enum,
     _coerce_formats,
+    _parse_and_localize_timestamp,
     plot_alerts,
 )
 
@@ -105,3 +108,51 @@ def test_plot_alerts_empty_df_does_nothing(caplog: pytest.LogCaptureFixture) -> 
     result = plot_alerts(df)
     assert result is None
     assert any("no plots generated" in msg.lower() for msg in caplog.text.splitlines())
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        ("2024-01-01 12:00", pd.Timestamp("2024-01-01 12:00", tz="UTC")),
+        (datetime(2024, 1, 1, 12, 0), pd.Timestamp("2024-01-01 12:00", tz="UTC")),
+        (pd.Timestamp("2024-01-01 12:00"), pd.Timestamp("2024-01-01 12:00", tz="UTC")),
+        (
+            pd.Timestamp("2024-01-01 12:00", tz="UTC"),
+            pd.Timestamp("2024-01-01 12:00", tz="UTC"),
+        ),
+        (None, pd.NaT),
+        ("not-a-timestamp", pd.NaT),
+        (pd.NaT, pd.NaT),
+        (float("nan"), pd.NaT),
+    ],
+)
+def test_parse_and_localize_timestamp_valid(
+    input_value: str | datetime | pd.Timestamp, expected_output: pd.Timestamp
+) -> None:
+    """Test scalar inputs are correctly parsed and localized or coerced to NaT."""
+    result = _parse_and_localize_timestamp(input_value)
+    if pd.isna(expected_output):
+        assert pd.isna(result)
+    else:
+        assert result == expected_output
+        assert result.tzinfo is not None and str(result.tzinfo) == "UTC"
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [
+        {"boom": "dict"},
+        ["2024-01-01"],
+        pd.Series(["2024-01-01"]),
+        pd.DataFrame({"a": [1]}),
+        set(["2024-01-01"]),
+        object(),
+    ],
+)
+def test_parse_and_localize_timestamp_invalid_inputs_return_nat(
+    invalid_input: object,
+) -> None:
+    """Test non-scalar inputs return NaT."""
+    assert not is_scalar(invalid_input)
+    result = _parse_and_localize_timestamp(invalid_input)
+    assert pd.isna(result)


### PR DESCRIPTION
Use `is_scalar()` in `_parse_and_localize_timestamp()` to reject `Series`, `lists`, `dicts`, etc. Adds tests for both valid and invalid input cases.