### PR TITLE
Fix workflow crash when requested inverter columns are missing in reporting data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,4 +11,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fixed a bug where the Solar Maintenance app would crash if some requested inverter components were missing from the reporting data. Missing components are now handled gracefully with a warning.

--- a/src/frequenz/lib/notebooks/solar/maintenance/solar_maintenance_app.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/solar_maintenance_app.py
@@ -210,6 +210,16 @@ async def run_workflow(
                 if components[0] == mid
                 for cid in components[1]
             ]
+            if missing_cols := set(real_time_view_col_to_plot) - set(
+                reporting_data_higher_fs.columns
+            ):
+                real_time_view_col_to_plot = list(
+                    set(real_time_view_col_to_plot) - set(missing_cols)
+                )
+                if config.verbose:
+                    print(
+                        f"Warning: Data is missing for the following components: {missing_cols}"
+                    )
             data_higher_fs = _filter_and_rename_columns(
                 reporting_data_higher_fs,
                 real_time_view_col_to_plot,


### PR DESCRIPTION
- Handled cases where the list of requested inverter component columns does not fully match the available reporting data columns.
- Added a check to remove missing columns and issue a warning.
- Prevents `KeyError` when slicing the DataFrame later in the workflow ensuring the app continues running even if some component data is unavailable.

This fix improves the robustness of the run_workflow() execution when partial inverter component data is returned from the reporting API.