### PR TITLE
Fix: Handle KeyError in StatisticalPlotStyle duration calculation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,3 +16,4 @@
 
 - Introduced `NoDataAvailableError` exception to represent situations where no data is available and to skip such cases during workflow execution and plotting.
 - Fixed a bug introduced in version `v0.5.2` where the microgrid tabular overview excluded current-day values from the total production for the past 30 and 365 days, causing inconsistencies with metrics that included today's data.
+- Fixed a crash in statistical plot style generation when the input data index is empty or contains only a single timestamp. Duration is now set to `None` when no `mode` can be determined.

--- a/src/frequenz/lib/notebooks/solar/maintenance/plot_styles.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/plot_styles.py
@@ -164,6 +164,8 @@ class StatisticalPlotStyle(PlotStyleStrategy):
                 .total_seconds()
                 / 60
             )
+        except KeyError:
+            duration = None  # occurs when data_index is empty or has a single value
 
         axes_params: dict[str, dict[str, str | int | list[str] | None]] = {
             "grouped": {


### PR DESCRIPTION
Catch `KeyError` when `data_index` is empty or has one entry, causing `mode()` to return an empty `Series` during duration calculation in `StatisticalPlotStyle.get_plot_styles()`. Set duration to `None` to allow plot style generation to proceed without error.