### PR TITLE
feat(plotter-data-preparer): include latest available data up to current timestamp

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
 ## New Features
 * Notification service: Introduced `NotificationSendError` for structured retry failure handling and updated the logging in `send_test_email()` utility function.
+* Rolling and profile plots now include production data up to the latest available timestamp, even if the current day is incomplete. This provides more real-time views of today's production without waiting for the day to finish.
 
 ## Bug Fixes
 

--- a/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
@@ -236,10 +236,7 @@ class RollingPreparer(BasePreparer):
             start = current.replace(hour=0, minute=0, second=0) - pd.Timedelta(
                 days=time
             )
-            stop = current.replace(
-                hour=23, minute=59, second=59, microsecond=1
-            ) - pd.Timedelta(days=1)
-            df_to_plot = df.loc[start:stop, :].resample("D").sum()
+            df_to_plot = df.loc[start:current, :].resample("D").sum()
             df_to_plot[self.config.x_axis_label] = [
                 item.strftime(self._date_format) for item in df_to_plot.index
             ]
@@ -250,8 +247,7 @@ class RollingPreparer(BasePreparer):
                 for item in pd.to_datetime(df_to_plot.index)
             ]
             start = current - pd.Timedelta(hours=time) + pd.Timedelta(microseconds=1)
-            stop = current
-            df_to_plot = df_to_plot.loc[start:stop, :]
+            df_to_plot = df_to_plot.loc[start:current, :]
         else:
             raise ValueError("Invalid time frame.")
         return df_to_plot
@@ -301,10 +297,7 @@ class ProfilePreparer(BasePreparer):
         current = df.index[-1]
         past_n_days = df.loc[
             current.replace(hour=0, minute=0, second=0)
-            - pd.Timedelta(days=self.config.duration) : current.replace(
-                hour=23, minute=59, second=59, microsecond=1
-            )
-            - pd.Timedelta(days=1)
+            - pd.Timedelta(days=self.config.duration) : current
         ]
 
         supported_groupings = {


### PR DESCRIPTION
Update `RollingPreparer` and `ProfilePreparer` to include data up to the latest available timestamp instead of limiting to the last completed day. This allows plotting today's partial data, providing more real-time insights.

The slicing now uses `current` instead of truncating at the end of the previous day.