### PR TITLE
feat: add MicrogridOverviewDashboard for dynamic multi-microgrid display

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 ## New Features
 
 - Introduced a `SolarAnalysisData` dataclass to structure the output of the `solar_maintenance_app.run_workflow()` function. This introduces a breaking change in the `Solar Maintenance.ipynb` notebook.
+- Added a modular `MicrogridOverviewDashboard` for dynamic multi-microgrid production display with light/dark theme support. Replaces the current hardcoded single-microgrid layout.
 
 ## Bug Fixes
 

--- a/src/frequenz/lib/notebooks/solar/maintenance/dashboard_styles.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/dashboard_styles.py
@@ -1,0 +1,256 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Styles and scripts for the microgrid overview dashboard."""
+
+STYLE_CONTENT = """
+<style>
+    .container {{
+        display: flex;
+        flex-wrap: wrap;
+        gap: 30px;
+        justify-content: center;
+    }}
+
+    /* Card Styles */
+    .card {{
+        width: 320px;
+        min-height: 380px;
+        padding: 20px;
+        border-radius: 12px;
+        background-color: #f8f9fa;
+        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        font-family: Arial, sans-serif;
+        transition: 0.3s;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }}
+
+    .card:hover {{
+        transform: translateY(-5px);
+        box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+        background-color: #eef0f3;
+    }}
+
+    .badge-wrapper {{
+        height: 24px;
+        margin-bottom: 10px;
+    }}
+
+    .badge {{
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: gold;
+        color: black;
+        font-weight: bold;
+        font-size: 14px;
+        padding: 6px 14px;
+        border-radius: 20px;
+        cursor: pointer;
+        white-space: nowrap;
+    }}
+
+    .badge-placeholder {{
+        height: 34px;
+    }}
+
+    .badge .tooltiptext {{
+        visibility: hidden;
+        width: 220px;
+        background-color: black;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        padding: 8px;
+        position: absolute;
+        z-index: 1;
+        bottom: 125%;
+        left: 50%;
+        margin-left: -110px;
+        opacity: 0;
+        transform: translateY(10px);
+        transition: opacity 0.4s ease, transform 0.4s ease;
+        font-size: 12px;
+        pointer-events: none;
+    }}
+
+    .badge:hover .tooltiptext {{
+        visibility: visible;
+        opacity: 1;
+        transform: translateY(0px);
+    }}
+
+    h3 {{
+        margin: 10px 0 15px 0;
+        font-size: 20px;
+        color: #333;
+    }}
+
+    .stats {{
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }}
+
+    .stat {{
+        display: flex;
+        justify-content: space-between;
+        background: #ffffff;
+        padding: 8px 12px;
+        border-radius: 6px;
+        border: 1px solid #eee;
+        font-size: 14px;
+    }}
+
+    .stat-title {{
+        color: #555;
+    }}
+
+    .stat-value {{
+        color: #555;
+        transition: color 0.3s ease;
+    }}
+
+    .highlight-green {{
+        color: green;
+        font-weight: bold;
+    }}
+
+    .highlight-red {{
+        color: red;
+        font-weight: bold;
+    }}
+
+    /* Dark Mode */
+    .dark-mode .card {{
+        background-color: #333;
+        color: #eee;
+    }}
+
+    .dark-mode .stat {{
+        background-color: #555;
+        border-color: #777;
+    }}
+
+    .dark-mode h3 {{
+        color: #eee;
+    }}
+
+    .dark-mode .stat-title {{
+        color: #eee;
+    }}
+
+    .dark-mode .stat-value {{
+        color: #eee;
+    }}
+
+    .dark-mode .highlight-green {{
+        color: #8f8;
+    }}
+
+    .dark-mode .highlight-red {{
+        color: #f88;
+    }}
+
+    .dark-mode .badge {{
+        background: orange;
+    }}
+
+    .dark-mode .badge .tooltiptext {{
+        background-color: #ccc;
+        color: #222;
+    }}
+
+    /* Toggle Switch */
+    .switch {{
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+    margin: 20px;
+    }}
+
+    .switch input {{
+    opacity: 0;
+    width: 0;
+    height: 0;
+    }}
+
+    .slider {{
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: background-color 0.4s;
+    border-radius: 34px;
+    }}
+
+    .slider-icon {{
+    position: absolute;
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: transform 0.4s, opacity 0.4s;
+    border-radius: 50%;
+    font-size: 18px;
+    text-align: center;
+    line-height: 26px;
+    }}
+
+    input:checked + .slider {{
+    background-color: #2196F3;
+    }}
+
+    input:checked + .slider .slider-icon {{
+    transform: translateX(26px);
+    opacity: 1;
+    }}
+</style>
+"""
+
+TOGGLE_HTML = """
+<label class="switch">
+    <input type="checkbox" id="theme-toggle" onclick="toggleDarkMode()" {checked}>
+    <span class="slider"><span class="slider-icon">{icon}</span></span>
+</label>
+"""
+
+TOGGLE_SCRIPT = """
+<script>
+    function toggleDarkMode() {{
+        document.body.classList.toggle('dark-mode');
+        updateSliderIcon();
+    }}
+
+    function updateSliderIcon() {{
+        const isDarkMode = document.body.classList.contains('dark-mode');
+        const sliderIcon = document.querySelector('.slider-icon');
+
+        if (sliderIcon) {{
+            sliderIcon.textContent = isDarkMode ? '🌒' : '☀️';
+        }}
+    }}
+
+    window.addEventListener('DOMContentLoaded', (event) => {{
+        updateSliderIcon();
+    }});
+</script>
+"""
+
+CLICK_SCRIPT_ONLOAD = """
+<script>
+    window.onload = function() {{
+        document.getElementById('theme-toggle').checked = true;
+        toggleDarkMode();
+    }};
+</script>
+"""

--- a/src/frequenz/lib/notebooks/solar/maintenance/dashboard_templates.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/dashboard_templates.py
@@ -1,0 +1,36 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Microgrid Overview Dashboard Templates."""
+
+CARD_TEMPLATE = """
+<div class="card">
+    {badge_html}
+    <h3>Microgrid ID: {microgrid_id}</h3>
+    <div class="stats">
+        {stats_html}
+    </div>
+</div>
+"""
+
+STAT_TEMPLATE = """
+<div class="stat">
+    <span class="stat-title">{col_name}</span>
+    <span class="stat-value {extra_class}">{value}</span>
+</div>
+"""
+
+BADGE_TEMPLATE = """
+<div class="badge-wrapper">
+    <div class="badge">
+        <span class="tooltiptext">Based on production today.</span>
+        🏆 Top Producer
+    </div>
+</div>
+"""
+
+BADGE_PLACEHOLDER_TEMPLATE = """
+<div class="badge-wrapper">
+    <div class="badge-placeholder"></div>
+</div>
+"""

--- a/src/frequenz/lib/notebooks/solar/maintenance/microgrid_dashboard.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/microgrid_dashboard.py
@@ -1,0 +1,174 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Microgrid Overview Dashboard.
+
+This module provides a class to create a card-based dashboard for microgrid
+production overview. The dashboard can display information about one or more
+mircogrids.
+"""
+
+from typing import TYPE_CHECKING, cast
+
+import pandas as pd
+from IPython.core.display import HTML
+from IPython.display import display
+from pandas import Series
+
+from .dashboard_styles import (
+    CLICK_SCRIPT_ONLOAD,
+    STYLE_CONTENT,
+    TOGGLE_HTML,
+    TOGGLE_SCRIPT,
+)
+from .dashboard_templates import (
+    BADGE_PLACEHOLDER_TEMPLATE,
+    BADGE_TEMPLATE,
+    CARD_TEMPLATE,
+    STAT_TEMPLATE,
+)
+
+if TYPE_CHECKING:
+    SeriesString = Series[str]
+else:
+    SeriesString = pd.Series
+
+
+class MicrogridOverviewDashboard:
+    """Class to create a microgrid production overview card-based dashboard."""
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        top_producer_column_idx: int,
+        default_theme: str = "light",
+    ):
+        """Initialize the dashboard with a DataFrame and column index.
+
+        Args:
+            df: Contains the data for the microgrid overview.
+            top_producer_column_idx: The index of the column to find the top
+                producer. The top producer is determined by the maximum value in
+                this column.
+            default_theme: The default theme for the dashboard, either "light"
+                or "dark".
+
+        Raises:
+            ValueError: If the default_theme is not "light" or "dark".
+        """
+        self.df = df
+        self.top_producer_column_idx = top_producer_column_idx
+        if default_theme not in ["light", "dark"]:
+            raise ValueError("default_theme must be 'light' or 'dark'")
+        self.default_theme = default_theme
+        self.checked = "checked" if self.default_theme == "dark" else ""
+
+    def _parse_number(self, s: str) -> float:
+        """Parse a localized string number.
+
+        Args:
+            s: The string to parse.
+
+        Returns:
+            The parsed number, or -inf if parsing fails.
+        """
+        try:
+            return float(s.replace(".", "").replace(",", "."))
+        except ValueError:
+            return float("-inf")
+
+    def _find_top_producer(self) -> int:
+        """Find the Microgrid ID with the highest value.
+
+        Returns:
+            The Microgrid ID of the top producer.
+        """
+        parsed_column = self.df.iloc[:, self.top_producer_column_idx].apply(
+            self._parse_number
+        )
+        idx_max = parsed_column.idxmax()
+        return cast(int, self.df.loc[idx_max, "Microgrid ID"])
+
+    def _should_display_top_producer_badge(self) -> bool:
+        """Determine if Top Producer badge should be shown.
+
+        Returns:
+            True if there is more than 1 row and not all top producer column
+            values are identical.
+        """
+        if len(self.df) <= 1:
+            return False
+        parsed_column = self.df.iloc[:, self.top_producer_column_idx].apply(
+            self._parse_number
+        )
+        return not parsed_column.eq(parsed_column.iloc[0]).all()
+
+    def _create_card(self, row: SeriesString, is_top: bool) -> str:
+        """Generate a single microgrid card.
+
+        Args:
+            row: The data for the microgrid.
+            is_top: Whether this microgrid is the top producer.
+
+        Returns:
+            The HTML for the microgrid card.
+        """
+        badge_html = BADGE_TEMPLATE if is_top else BADGE_PLACEHOLDER_TEMPLATE
+        stats_html = "".join(
+            STAT_TEMPLATE.format(
+                col_name=col,
+                value=row[col],
+                extra_class=(
+                    "highlight-red" if self._parse_number(row[col]) == 0 else ""
+                ),
+            )
+            for col in self.df.columns
+            if col != "Microgrid ID"
+        )
+        return CARD_TEMPLATE.format(
+            microgrid_id=row["Microgrid ID"],
+            badge_html=badge_html,
+            stats_html=stats_html,
+        )
+
+    def _generate_cards(self) -> str:
+        """Generate HTML for all cards."""
+        show_badge = self._should_display_top_producer_badge()
+        top_producer_id = self._find_top_producer() if show_badge else None
+        return "".join(
+            self._create_card(
+                row, show_badge and row["Microgrid ID"] == top_producer_id
+            )
+            for _, row in self.df.iterrows()
+        )
+
+    def _generate_full_html(self) -> str:
+        """Assemble the full HTML page."""
+        if self.default_theme == "dark":
+            theme_class = "dark-mode"
+            click_script = CLICK_SCRIPT_ONLOAD
+            icon = "🌒"
+        else:
+            theme_class = ""
+            icon = "☀️"
+            click_script = ""
+
+        return f"""
+        <body class='{theme_class}'>
+            {STYLE_CONTENT.format(checked=self.checked)}
+            {TOGGLE_HTML.format(checked=self.checked, icon=icon)}
+            {TOGGLE_SCRIPT}
+            <div class="container">
+                {self._generate_cards()}
+            </div>
+            {click_script}
+        </body>
+        """
+
+    def to_html(self) -> str:
+        """Return the full dashboard HTML."""
+        return self._generate_full_html()
+
+    def render(self) -> None:
+        """Display the dashboard."""
+        display(HTML(self.to_html()))  # type: ignore[no-untyped-call]


### PR DESCRIPTION
Add a modular `MicrogridOverviewDashboard` to dynamically render multiple microgrid production cards.
- Replaces old hardcoded single-microgrid layout.
- Modularizes layout (HTML templates) and styles (CSS/JS) into separate files.
- Supports light/dark themes and dynamic badge display.

Prepares the codebase for future support of the app outside of Deepnote.