### PR TITLE
Fix: Include current-day production

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,3 +14,4 @@
 ## Bug Fixes
 
 - Introduced `NoDataAvailableError` exception to represent situations where no data is available and to skip such cases during workflow execution and plotting.
+- Fixed a bug introduced in version `v0.5.2` where the microgrid tabular overview excluded current-day values from the total production for the past 30 and 365 days, causing inconsistencies with metrics that included today's data.

--- a/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
@@ -477,10 +477,7 @@ class StatsPreparer(BasePreparer):
                         "{:.2f}".format(
                             df.loc[
                                 current.replace(hour=0, minute=0, second=0)
-                                - pd.Timedelta(days=30) : current.replace(
-                                    hour=23, minute=59, second=59
-                                )
-                                - pd.Timedelta(days=1)
+                                - pd.Timedelta(days=30) : current
                             ].energy_kWh.sum()
                         )
                     )
@@ -503,10 +500,7 @@ class StatsPreparer(BasePreparer):
                         "{:.2f}".format(
                             df.loc[
                                 current.replace(hour=0, minute=0, second=0)
-                                - pd.Timedelta(days=365) : current.replace(
-                                    hour=23, minute=59, second=59
-                                )
-                                - pd.Timedelta(days=1)
+                                - pd.Timedelta(days=365) : current
                             ].energy_MWh.sum()
                         )
                     )


### PR DESCRIPTION
Fixed a bug introduced in version `v0.5.2` where the microgrid tabular overview excluded current-day values from the total production for the past 30 and 365 days, causing inconsistencies with metrics that included today's data.