### PR TITLE
Broaden numpy dependency version range to allow v1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 ## Upgrading
 
+* Adds back support for numpy v1.26.4+ while keeping compatibility with numpy v2.
+
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.12.2, < 5",
-  "numpy >= 2.0, < 3",
+  "numpy >= 1.26.4, < 3",
   "pandas >= 2.2.2, < 3",
   "matplotlib >= 3.8.4, < 3.11.0",
   "ipython == 9.3.0",
@@ -37,7 +37,7 @@ dependencies = [
   "plotly >= 6.0.0, < 6.2.0",
   "kaleido >= 0.2.1, < 0.3.0",
   "frequenz-client-reporting >= 0.16.0, < 0.17.0",
-  "frequenz-client-weather >= 0.2.0, < 0.3.0",
+  "frequenz-client-weather >= 0.2.1, < 0.3.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Support using this library in projects that haven't been migrated yet. Requires update of the weather client too.