### PR TITLE
Remove internal empty-data check from retrieve_data()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Removed internal empty-data check from `data_fetch.retrieve_data()`. The app now consistently handles missing reporting data by raising `NoDataAvailableError`.

--- a/src/frequenz/lib/notebooks/solar/maintenance/data_fetch.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/data_fetch.py
@@ -153,7 +153,6 @@ async def retrieve_data(
         ValueError:
             - If no service address or file path provided for weather or
                 reporting data.
-            - If no data is retrieved from the reporting API.
             - If the file path does not end with '.csv'.
         TypeError: If an unknown configuration type is provided.
     """
@@ -193,8 +192,6 @@ async def retrieve_data(
                     resampling_period=timedelta(seconds=config.resample_period_seconds),
                 )
             ]
-            if not reporting_data:
-                raise ValueError("No data retrieved from the reporting API.")
             return pd.DataFrame(reporting_data)
         if config.file_path:
             if config.verbose:


### PR DESCRIPTION
The check for empty reporting data was removed from `retrieve_data()` because the calling application already handles this case and raises a `NoDataAvailableError`. Keeping this check caused the app to fail prematurely with a generic `ValueError`. This change ensures consistent error handling and allows the app to control the flow.