### PR TITLE
Add transactional stateful data fetcher

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - Added consistent logger setup across all modules for structured logging and improved observability. Example notebooks updated to demonstrate logger usage.
 - The signature for passing config files MicrogridConfig.load_config() has been changed to accept a path a list of paths and a directory containing the config files.
 - `MicrogridData` class needs to be initialized with a `MicrogridConfig` object instead of a path to config file(s).
+- Added a transactional stateful data fetcher.
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "typing-extensions >= 4.12.2, < 5",
   "numpy >= 2.3.1, < 3",
   "pandas >= 2.3.1, < 3",
+  "pyarrow >= 20.0.0, < 21.0.0",
   "matplotlib >= 3.8.4, < 3.11.0",
   "ipython == 9.3.0",
   "pvlib >= 0.13.0, < 0.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.12.2, < 5",
-  "numpy >= 1.26.4, < 3",
-  "pandas >= 2.2.2, < 3",
+  "numpy >= 2.3.1, < 3",
+  "pandas >= 2.3.1, < 3",
   "matplotlib >= 3.8.4, < 3.11.0",
   "ipython == 9.3.0",
   "pvlib >= 0.13.0, < 0.14.0",

--- a/src/frequenz/data/microgrid/__init__.py
+++ b/src/frequenz/data/microgrid/__init__.py
@@ -3,10 +3,12 @@
 
 """Initialize the microgrid data module."""
 
+from ._stateful_data_fetcher import StatefulDataFetcher
 from .component_data import MicrogridData
 from .config import MicrogridConfig
 
 __all__ = [
     "MicrogridConfig",
     "MicrogridData",
+    "StatefulDataFetcher",
 ]

--- a/src/frequenz/data/microgrid/_stateful_data_fetcher.py
+++ b/src/frequenz/data/microgrid/_stateful_data_fetcher.py
@@ -1,0 +1,274 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+"""A helper module to write data exports.
+
+This class is a wrapper around the `MicrogridData` class to add state
+designed for continuous data exports. It not only receives data, but also
+writes the latest data point to an on disc buffer. The timestamp in the
+buffer is then used as the start time for the next run.
+
+Furthermore this module introduces a transactional approach to updating
+the on disc buffer to ensure data integrity:
+
+- Buffer updates are written to a temporary file (e.g.,
+data.parquet.tmp).
+- On success: The temporary file is atomically renamed to its final
+path, committing the new buffer state.
+- On failure: The temporary file is deleted, rolling back the change.
+
+This ensures the unprocessed data will be fetched again on the next
+run.
+
+???+ example
+
+    ```python
+    REPORTING_API_KEY = "your_api_key"
+    REPORTING_API_SECRET = "your_api_secret"
+
+    mid = 12345
+    component_name = "battery"
+    metric = "active_power"
+
+    mg_config = MicrogridConfig.load_configs(
+        microgrid_config_dir=Path("/path/to/microgrid/configs")
+    )
+    mg_data = MicrogridData(
+        "https://reporting.example.com",
+        REPORTING_API_KEY,
+        REPORTING_API_SECRET,
+        mg_config,
+    )
+
+    data_fetcher = StatefulDataFetcher(
+        microgrid_data,
+        data_buffer_dir=Path("/path/to/data/buffer"),
+        resampling_period=timedelta(seconds=180),
+    ),
+
+    try:
+        data = await data_fetcher.receive_microgrid_data(
+            mid,
+            component_name,
+            metric,
+        )
+        _logger.debug(
+            "Data fetched for %s: %s", location.component.name, data
+        )
+    except ValueError as e:
+        _logger.error("Error fetching data for AKS ID %s: %s", aks_id, e)
+
+    # do sth with data
+    # ...
+
+    data_fetcher.commit()  # Commit the changes if successful
+    # data_fetcher.rollback()  # Rollback if there was an error
+    ```
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from .component_data import MicrogridData
+
+_logger = logging.getLogger(__name__)
+
+# Number of data points to keep in the buffer. We only look at the last 1 data
+# point but can be increased if needed for debugging or testing purposes.
+BUFFER_SIZE = 1
+
+# The reporting API implementation follows an eventually consistent system design
+# and therefore we use a 15-minute delta to get a high probability that the
+# received data is stabilized.
+END_TIME_DELTA = timedelta(minutes=15)
+
+
+class StatefulDataFetcher:
+    """A helper class to handle fetching of microgrid component data.
+
+    This class provides methods to query new data for a specific microgrid and
+    its components, and to write the updated data to a temporary file.
+    The file is written only temporarily and needs to be committed or rolled back
+    in case of success or failure, respectively.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        self,
+        microgrid_data: MicrogridData,
+        data_buffer_dir: Path,
+        resampling_period: timedelta,
+        end_time_delta: timedelta = END_TIME_DELTA,
+        initial_period: timedelta = timedelta(hours=1),
+    ) -> None:
+        """Initialize the TransactionalDataExport class.
+
+        Args:
+            microgrid_data: An instance of MicrogridData to query data from.
+            data_buffer_dir: The path to the directory for buffering data.
+            resampling_period: The period to resample the data.
+            end_time_delta: The time subtracted from now to be passed as
+                            end_time to the API.
+            initial_period: The initial period to use for the first data fetch.
+        """
+        _logger.debug("Initializing StatefulDataFetcher instance.")
+        self._microgrid_data = microgrid_data
+        self._data_buffer = data_buffer_dir
+        self._resampling_period = resampling_period
+        self._end_time_delta = end_time_delta
+        self._initial_period = initial_period
+
+        self._data_buffer.mkdir(parents=True, exist_ok=True)
+
+        # Maps temp_path -> final_path for files that need to be committed
+        self._temp_files_to_commit: dict[Path, Path] = {}
+
+    @staticmethod
+    def _generate_filename(
+        microgrid_id: int, components: tuple[str, ...], metric: str
+    ) -> str:
+        """Generate a unique, sanitized filename.
+
+        Args:
+            microgrid_id: The ID of the microgrid.
+            components: The component types to include in the filename.
+            metric: The name of the metric to include in the filename.
+
+        Returns:
+            A sanitized string suitable for use as a filename.
+        """
+        sorted_components = sorted([c.lower().replace(" ", "_") for c in components])
+        return (
+            f"mid{microgrid_id}_{'_'.join(sorted_components)}_{metric.lower()}.parquet"
+        )
+
+    async def receive_microgrid_data(
+        self,
+        microgrid_id: int,
+        components: tuple[str, ...],
+        metric: str,
+    ) -> pd.DataFrame | None:
+        """Query new microgrid data and write the updated buffer to a temp file.
+
+        Reads the last timestamp from the main buffer file, queries for new data,
+        and writes the combined data to a new temporary buffer file.
+
+        Args:
+            microgrid_id: The ID of the microgrid to query.
+            components: The component types to include in the query.
+            metric: The metric to query.
+
+        Returns:
+            A pandas DataFrame with only the new data points, or None.
+        """
+        _logger.debug(
+            "Processing data for microgrid ID %s, components %s",
+            microgrid_id,
+            components,
+        )
+
+        final_parquet_file = self._data_buffer / self._generate_filename(
+            microgrid_id, components, metric
+        )
+        temp_parquet_file = final_parquet_file.with_suffix(
+            final_parquet_file.suffix + ".tmp"
+        )
+
+        now = datetime.now(timezone.utc)
+        end_time = now - self._end_time_delta
+        on_disk_buffer = pd.DataFrame()
+        start_time: datetime
+
+        try:
+            on_disk_buffer = pd.read_parquet(final_parquet_file)
+            if not on_disk_buffer.empty and isinstance(
+                on_disk_buffer.index, pd.DatetimeIndex
+            ):
+                last_timestamp = on_disk_buffer.index.max().to_pydatetime()
+                start_time = last_timestamp + timedelta(microseconds=1)
+                _logger.info("Read buffer. Last timestamp: %s.", last_timestamp)
+            else:
+                _logger.info(
+                    "Buffer file is empty. Defaulting to: %s.", self._initial_period
+                )
+                start_time = now - self._initial_period
+        except FileNotFoundError:
+            _logger.info(
+                "No buffer file at '%s'. Defaulting to %s.",
+                final_parquet_file,
+                self._initial_period,
+            )
+            start_time = now - self._initial_period
+
+        if start_time >= end_time:
+            _logger.info("Buffer is up to date. No new data to fetch.")
+            return None
+
+        _logger.info("Fetching new data from %s to %s...", start_time, end_time)
+
+        new_df = await self._microgrid_data.metric_data(
+            microgrid_id=microgrid_id,
+            start=start_time,
+            end=end_time,
+            component_types=components,
+            resampling_period=self._resampling_period,
+            metric=metric,
+        )
+
+        if new_df is not None and not new_df.empty:
+            _logger.info("Fetched %d new data points.", len(new_df))
+            combined_df = pd.concat([on_disk_buffer, new_df])
+            combined_df = combined_df[~combined_df.index.duplicated(keep="last")]
+            combined_df.sort_index(inplace=True)
+            updated_buffer = combined_df.tail(BUFFER_SIZE)
+
+            # Write to temporary file instead of final destination
+            updated_buffer.to_parquet(temp_parquet_file, engine="pyarrow")
+
+            _logger.info(
+                "Wrote updated buffer with %d points to temporary file '%s'.",
+                len(updated_buffer),
+                temp_parquet_file,
+            )
+
+            self._temp_files_to_commit[temp_parquet_file] = final_parquet_file
+        else:
+            _logger.info("No new data was returned from the API.")
+
+        return new_df
+
+    def commit(self) -> None:
+        """Commit the temporary files to their final locations."""
+        _logger.info("Reports sent successfully. Committing buffer updates.")
+        for temp_path, final_path in self._temp_files_to_commit.items():
+            try:
+                os.replace(temp_path, final_path)
+                _logger.debug(
+                    "Committed buffer update: %s -> %s", temp_path, final_path
+                )
+            except OSError as e:
+                _logger.error(
+                    "Failed to commit buffer update from %s to %s: %s",
+                    temp_path,
+                    final_path,
+                    e,
+                )
+
+        self._temp_files_to_commit.clear()
+
+    def rollback(self) -> None:
+        """Rollback the temporary files if the transaction fails."""
+        for temp_path in self._temp_files_to_commit:
+            try:
+                temp_path.unlink()
+                _logger.debug("Rolled back by deleting temp file: %s", temp_path)
+            except OSError as unlink_e:
+                _logger.error(
+                    "Failed to clean up temporary buffer file %s during rollback: %s",
+                    temp_path,
+                    unlink_e,
+                )
+
+        self._temp_files_to_commit.clear()

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -1,0 +1,235 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the frequenz.data.microgrid._stateful_data_fetcher module."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from frequenz.data.microgrid import StatefulDataFetcher
+
+
+@pytest.fixture
+def mock_microgrid_data() -> MagicMock:
+    """Provide a mock for the MicrogridData dependency."""
+    return MagicMock()
+
+
+@pytest.fixture
+def data_fetcher(tmp_path: Path, mock_microgrid_data: MagicMock) -> StatefulDataFetcher:
+    """Provide an instance of StatefulDataFetcher with a temporary buffer directory."""
+    return StatefulDataFetcher(
+        microgrid_data=mock_microgrid_data,
+        data_buffer_dir=tmp_path,
+        resampling_period=timedelta(seconds=360),
+    )
+
+
+class TestStatefulDataFetcher:
+    """Unit tests for the StatefulDataFetcher class."""
+
+    def test_initialization(self, tmp_path: Path) -> None:
+        """Test that the data buffer directory is created on initialization."""
+        assert not (tmp_path / "data").exists()
+        StatefulDataFetcher(
+            microgrid_data=MagicMock(),
+            data_buffer_dir=tmp_path / "data",
+            resampling_period=timedelta(seconds=360),
+        )
+        assert (tmp_path / "data").exists()
+
+    def test_generate_filename(self, data_fetcher: StatefulDataFetcher) -> None:
+        """Test the filename generation logic."""
+        filename = data_fetcher._generate_filename(  # pylint: disable=protected-access
+            microgrid_id=123, components=("Battery", "Grid Meter"), metric="Power"
+        )
+        # Components should be sorted alphabetically and lowercased
+        assert filename == "mid123_battery_grid_meter_power.parquet"
+
+    @patch("frequenz.data.microgrid._stateful_data_fetcher.datetime")
+    async def test_receive_data_no_initial_file(
+        self,
+        mock_datetime: MagicMock,
+        data_fetcher: StatefulDataFetcher,
+        mock_microgrid_data: MagicMock,
+    ) -> None:
+        """Test fetching data when no previous buffer file exists."""
+        # pylint: disable=protected-access
+        # --- Setup ---
+        fixed_now = datetime(2025, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_now
+
+        start_time = fixed_now - timedelta(hours=1)
+        end_time = fixed_now - data_fetcher._end_time_delta
+
+        new_data = pd.DataFrame(
+            {"value": [1.0, 2.0]},
+            index=pd.to_datetime(
+                [
+                    start_time + timedelta(minutes=1),
+                    start_time + timedelta(minutes=2),
+                ],
+                utc=True,
+            ),
+        )
+        mock_microgrid_data.metric_data = AsyncMock(return_value=new_data)
+
+        # --- Execution ---
+        result_df = await data_fetcher.receive_microgrid_data(
+            microgrid_id=1, components=("Battery",), metric="SoC"
+        )
+
+        # --- Assertions ---
+        mock_microgrid_data.metric_data.assert_awaited_once_with(
+            microgrid_id=1,
+            start=start_time,
+            end=end_time,
+            component_types=("Battery",),
+            resampling_period=data_fetcher._resampling_period,
+            metric="SoC",
+        )
+
+        # Check that a temp file was created and is pending commit
+        assert len(data_fetcher._temp_files_to_commit) == 1
+        temp_file = list(data_fetcher._temp_files_to_commit.keys())[0]
+        assert temp_file.name.endswith(".parquet.tmp")
+
+        # Check the content of the written file (tailed to BUFFER_SIZE=1)
+        written_data = pd.read_parquet(temp_file)
+        assert len(written_data) == 1
+        pd.testing.assert_frame_equal(written_data, new_data.tail(1))
+
+        # Check that the returned dataframe is the complete new data
+        assert result_df is not None
+        pd.testing.assert_frame_equal(result_df, new_data)
+
+    @patch("frequenz.data.microgrid._stateful_data_fetcher.datetime")
+    async def test_receive_data_with_existing_file(
+        self,
+        mock_datetime: MagicMock,
+        data_fetcher: StatefulDataFetcher,
+        mock_microgrid_data: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test fetching data when a buffer file already exists."""
+        # pylint: disable=protected-access
+        # --- Setup ---
+        fixed_now = datetime(2025, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_now
+
+        # Create an existing buffer file
+        last_timestamp = fixed_now - timedelta(hours=1)
+        on_disk_buffer = pd.DataFrame(
+            {"value": [100.0]}, index=pd.to_datetime([last_timestamp], utc=True)
+        )
+        final_file_path = tmp_path / "mid2_inverter_power.parquet"
+        on_disk_buffer.to_parquet(final_file_path)
+
+        # This is the new data the API will return
+        new_data_start_time = last_timestamp + timedelta(minutes=3)
+        new_data = pd.DataFrame(
+            {"value": [101.0]}, index=pd.to_datetime([new_data_start_time], utc=True)
+        )
+        mock_microgrid_data.metric_data = AsyncMock(return_value=new_data)
+
+        # --- Execution ---
+        await data_fetcher.receive_microgrid_data(
+            microgrid_id=2, components=("Inverter",), metric="Power"
+        )
+
+        # --- Assertions ---
+        # Start time should be based on the last timestamp from the file
+        expected_start_time = last_timestamp + timedelta(microseconds=1)
+        mock_microgrid_data.metric_data.assert_awaited_once()
+        call_args = mock_microgrid_data.metric_data.call_args[1]
+        assert call_args["start"] == expected_start_time
+
+        # A temp file should be pending commit
+        assert len(data_fetcher._temp_files_to_commit) == 1
+        temp_file = list(data_fetcher._temp_files_to_commit.keys())[0]
+
+        # The new buffer should contain the latest point
+        written_data = pd.read_parquet(temp_file)
+        assert len(written_data) == 1
+        pd.testing.assert_frame_equal(written_data, new_data)
+
+    @patch("frequenz.data.microgrid._stateful_data_fetcher.datetime")
+    async def test_receive_data_up_to_date(
+        self,
+        mock_datetime: MagicMock,
+        data_fetcher: StatefulDataFetcher,
+        mock_microgrid_data: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that no data is fetched if the buffer is already up to date."""
+        # pylint: disable=protected-access
+        # --- Setup ---
+        fixed_now = datetime(2025, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_now
+
+        # Last timestamp is within the END_TIME_DELTA, so we are "up-to-date"
+        last_timestamp = fixed_now - data_fetcher._end_time_delta + timedelta(minutes=1)
+        on_disk_buffer = pd.DataFrame(
+            {"value": [50.0]}, index=pd.to_datetime([last_timestamp], utc=True)
+        )
+        final_file_path = tmp_path / "mid3_meter_power.parquet"
+        on_disk_buffer.to_parquet(final_file_path)
+
+        mock_microgrid_data.metric_data = AsyncMock()
+
+        # --- Execution ---
+        result = await data_fetcher.receive_microgrid_data(
+            microgrid_id=3, components=("Meter",), metric="Power"
+        )
+
+        # --- Assertions ---
+        assert result is None
+        mock_microgrid_data.metric_data.assert_not_awaited()
+        assert not data_fetcher._temp_files_to_commit
+
+    async def test_receive_data_api_returns_nothing(
+        self, data_fetcher: StatefulDataFetcher, mock_microgrid_data: MagicMock
+    ) -> None:
+        """Test behavior when the data API returns None or an empty DataFrame."""
+        # pylint: disable=protected-access
+        mock_microgrid_data.metric_data = AsyncMock(return_value=pd.DataFrame())
+
+        result = await data_fetcher.receive_microgrid_data(
+            microgrid_id=4, components=("EV Charger",), metric="Current"
+        )
+
+        assert isinstance(result, pd.DataFrame) and result.empty
+        mock_microgrid_data.metric_data.assert_awaited_once()
+        assert not data_fetcher._temp_files_to_commit  # No temp file should be created
+
+    @patch("frequenz.data.microgrid._stateful_data_fetcher.os.replace")
+    def test_commit(
+        self, mock_os_replace: MagicMock, data_fetcher: StatefulDataFetcher
+    ) -> None:
+        """Test the commit functionality."""
+        # pylint: disable=protected-access
+        temp_path = Path("/tmp/file.tmp")
+        final_path = Path("/tmp/file.final")
+        data_fetcher._temp_files_to_commit = {temp_path: final_path}
+
+        data_fetcher.commit()
+
+        mock_os_replace.assert_called_once_with(temp_path, final_path)
+
+    @patch("pathlib.Path.unlink")
+    def test_rollback(
+        self, mock_unlink: MagicMock, data_fetcher: StatefulDataFetcher
+    ) -> None:
+        """Test the rollback functionality."""
+        # pylint: disable=protected-access
+        temp_path = Path("/tmp/file.tmp")
+        final_path = Path("/tmp/file.final")
+        data_fetcher._temp_files_to_commit = {temp_path: final_path}
+
+        data_fetcher.rollback()
+
+        mock_unlink.assert_called_once()


### PR DESCRIPTION
This class is a wrapper around the `MicrogridData` class to add state designed for continues data exports. It not only receives data, but also writes the latest data point to an on disc buffer. The timestamp in the buffer is then used as the start time for the next run.

Furthermore this module introduces a transactional approach to updating the on disc buffer to ensure data integrity:

* Buffer updates are written to a temporary file (e.g., `data.parquet.tmp`).
* On success: The temporary file is atomically renamed to its final path, committing the new buffer state.
* On failure: The temporary file is deleted, rolling back the change.

This ensures the unprocessed data will be fetched again on the next run.