### PR TITLE
Use df.loc instead of df.at for mypy compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,15 +61,15 @@ dev-mkdocs = [
   "mike == 2.1.3",
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.2",
-  "mkdocs-macros-plugin == 1.3.7",
-  "mkdocs-material == 9.6.16",
+  "mkdocs-macros-plugin == 1.3.9",
+  "mkdocs-material == 9.6.18",
   "mkdocstrings[python] == 0.30.0",
   "mkdocstrings-python == 1.18.2",
   "frequenz-repo-config[lib] == 0.13.5",
 ]
 dev-mypy = [
   "mypy == 1.17.1",
-  "pandas-stubs == 2.3.0.250703",
+  "pandas-stubs == 2.3.2.250827",
   "types-toml==0.10.8.20240310",
   "types-Markdown == 3.8.0.20250809",
   # For checking the noxfile, docs/ script, and tests
@@ -86,7 +86,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.4.1",
-  "pylint == 3.3.7",       # We need this to check for the examples
+  "pylint == 3.3.8",       # We need this to check for the examples
   "frequenz-repo-config[extra-lint-examples] == 0.13.5",
   "pytest-mock == 3.14.1",
   "pytest-asyncio == 1.1.0",

--- a/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/plotter_data_preparer.py
@@ -449,7 +449,7 @@ class StatsPreparer(BasePreparer):
             {
                 self.config.translation_manager.translate("Current yield (kWh)"): [
                     self.config.translation_manager.translate(
-                        "{:.2f}".format(df.at[current, "energy_kWh"])
+                        "{:.2f}".format(df.loc[current, "energy_kWh"])
                     )
                 ],
                 self.config.translation_manager.translate("Yield today (kWh)"): [


### PR DESCRIPTION
- Replaced `df.at` with `df.loc` to avoid mypy type errors related to string formatting.
- `.loc` provides better type inference vs `.at`, which returns `Any`. No functional changes — current index is unique and always yields a scalar.
- Bumped the patch group with 4 updates