### PR TITLE
fix: skip transformations when input data is empty

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,14 +6,13 @@
 
 ## Upgrading
 
-* Widen weather API dependency range to reduce conflicts with other packages.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-* Add flag to indicate whether PV is curtailable.
-* Add asset optimization reporting package with data fetcher and visualization module.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
 * Replaces multiple duplicated plot functions with a single reusable one.
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Handle empty weather/reporting dataframes gracefully to avoid transformation errors.

--- a/src/frequenz/lib/notebooks/solar/maintenance/data_fetch.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/data_fetch.py
@@ -227,6 +227,9 @@ def transform_weather_data(
     Raises:
         ValueError: If missing or invalid date entries are found in 'validity_ts'.
     """
+    if data.empty:
+        _logger.info("No weather data available to transform.")
+        return data
     _logger.info("Transforming weather forecast data...")
     weather_forecasts_df, nat_present = transform_weather_features(
         data=data,
@@ -266,6 +269,9 @@ def transform_reporting_data(
     Returns:
         The transformed reporting data.
     """
+    if data.empty:
+        _logger.info("No reporting data available to transform.")
+        return data
     _logger.info("Transforming reporting data...")
 
     if microgrid_components:

--- a/src/frequenz/lib/notebooks/solar/maintenance/data_processing.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/data_processing.py
@@ -143,11 +143,15 @@ def preprocess_data(
     if time_diff_seconds_series.nunique() == 1:
         time_diff_seconds = time_diff_seconds_series.values[0]
     else:
-        _logger.warning(
-            "Detected multiple unique time differences; this may indicate inconsistent "
-            "timestamps. Falling back to the mode of the time differences."
-        )
         time_diff_seconds = time_diff_seconds_series.mode()[0]
+        _logger.debug(
+            "Multiple time deltas detected (%s unique: %s seconds). "
+            "Falling back to (statistical) mode=%s seconds.",
+            time_diff_seconds_series.nunique(),
+            time_diff_seconds_series.unique(),
+            time_diff_seconds,
+        )
+
     for unit in energy_units:
         energy_factor, base_unit = parse_unit(unit)
         time_conversion_factor = valid_time_units.get(base_unit[1:], None)

--- a/src/frequenz/lib/notebooks/solar/maintenance/solar_maintenance_app.py
+++ b/src/frequenz/lib/notebooks/solar/maintenance/solar_maintenance_app.py
@@ -270,8 +270,7 @@ async def run_workflow(user_config_changes: dict[str, Any]) -> SolarAnalysisData
                     set(real_time_view_col_to_plot) - set(missing_cols)
                 )
                 _logger.warning(
-                    "Warning: Data is missing for the following components: %s",
-                    missing_cols,
+                    "Data is missing for the following components: %s", missing_cols
                 )
             data_higher_fs = _filter_and_rename_columns(
                 reporting_data_higher_fs, real_time_view_col_to_plot


### PR DESCRIPTION
Avoids errors when no weather or reporting data is fetched. Logs a
message and exits early from transformation functions if the input
DataFrame is empty.

Also updated a couple of log messages.