### PR TITLE
Revert "Widen weather API client dependency range (#145)"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* Revert back to `v0.2.3` of the weather-client until the weather service is able to support `v0.13` of the weather API.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "toml >= 0.10.2, < 0.11.0",
   "plotly >= 6.0.0, < 6.4.0",
   "kaleido >= 0.2.1, < 1.1.0",
-  "frequenz-client-reporting >= 0.18.0, < 0.20.0",
+  "frequenz-client-reporting >= 0.19.0, < 0.20.0",
   "frequenz-client-weather >= 0.2.3, < 0.3.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "plotly >= 6.0.0, < 6.4.0",
   "kaleido >= 0.2.1, < 1.1.0",
   "frequenz-client-reporting >= 0.18.0, < 0.20.0",
-  "frequenz-client-weather >= 0.2.2, < 0.4.0",
+  "frequenz-client-weather >= 0.2.3, < 0.3.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This reverts commit 33fe0fe. `v0.3.0` of the weather client has a breaking
change which affects the module `frequenz.datasci.weather.weather_api.py`
In particular, the client method `hist_forecast_iterator` is replaced by
the `async` method `stream_historical_forecast`. Also, `v0.3.0` uses a
new version of the API, that the weather service doesn't support yet.
When the service supports it, the client dependency should be updated
to minimum `v0.3.0` due to the breaking change.

It also bumps `frequenz-client-reporting` to min `v0.19.0`