### PR TITLE
fix: render component IDs as plain ints in alert email summaries

### DIFF
--- a/src/frequenz/lib/notebooks/alerts/alert_email.py
+++ b/src/frequenz/lib/notebooks/alerts/alert_email.py
@@ -303,7 +303,7 @@ def generate_alert_summary(
                 "state_value",
                 lambda x: [html.escape(str(s)) for s in x.unique()],
             ),
-            unique_components=("component_id", lambda x: list(x.unique())),
+            unique_components=("component_id", lambda x: [int(c) for c in x.unique()]),
         )
         .reset_index()
     )


### PR DESCRIPTION
Previously, component IDs in alert summaries were shown as `numpy.int64` objects, which rendered in emails like:

    Components: [np.int64(1122), np.int64(1123), ...]

This commit ensures component IDs are converted to plain Python ints during aggregation, so they display cleanly as:

    Components: [1122, 1123, 1124, 1125, 1126, 1127, 1128, 1129, 1130]

This improves readability and avoids confusion for users receiving alert emails.