### PR TITLE
Add more WindConfig fields in microgrid config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-* Revert back to `v0.2.3` of the weather-client until the weather service is able to support `v0.13` of the weather API.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
@@ -14,5 +14,4 @@
 
 ## Bug Fixes
 
-* Replaces multiple duplicated plot functions with a single reusable one.
-* Handle empty weather/reporting dataframes gracefully to avoid transformation errors. The "Solar Maintenance" notebook is updated accordingly.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* Add fields to `WindConfig` for microgrid configuration.
 
 ## Bug Fixes
 

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -137,7 +137,7 @@ class WindConfig:
     turbine_height: float | None = None
     """Height of the wind turbine in meters."""
 
-    number_of_turbines: int | None = None
+    number_of_turbines: int = 1
     """Number of wind turbines."""
 
     hellmann_exponent: float | None = None

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -137,6 +137,18 @@ class WindConfig:
     turbine_height: float | None = None
     """Height of the wind turbine in meters."""
 
+    number_of_turbines: int | None = None
+    """Number of wind turbines."""
+
+    hellmann_exponent: float | None = None
+    """Hellmann exponent for wind speed extrapolation. See: https://w.wiki/FMw9"""
+
+    longitude: float | None = None
+    """Geographic longitude of the wind turbine."""
+
+    latitude: float | None = None
+    """Geographic latitude of the wind turbine."""
+
 
 @dataclass(frozen=True)
 class BatteryConfig:


### PR DESCRIPTION
Fields are added to support multiple turbines with the same settings, wind turbine location as well as a Hellman exponent that can be used for a simple wind speed adjustment w.r.t. height.