### PR TITLE
Add microgrid and enterprise ID to microgrid config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 * Add fields to `WindConfig` for microgrid configuration.
+* Add microgrid and enterprise ID to microgrid metadata config.
 
 ## Bug Fixes
 

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -172,12 +172,19 @@ class AssetsConfig:
     """Configuration of the batteries."""
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Metadata:
     """Metadata for a microgrid."""
 
     name: str | None = None
     """Name of the microgrid."""
+
+    microgrid_id: int | None = None
+    """ID of the microgrid."""
+
+    enterprise_id: int | None = None
+    """Enterprise ID of the microgrid."""
 
     gid: int | None = None
     """Gridpool ID of the microgrid."""


### PR DESCRIPTION
To support having self-contained config objects.