### PR TITLE
Switch to schema-based microgrid config loading

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,10 @@
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
+- `MicrogridConfig`: Switch to schema-based loading of microgrid config files and updates to the config class:
+   - Remove unused nested field `assets` and replace by its contents `pv`, `wind`, `battery`.
+   - Make `meta` and `ctype` public fields.
+   - Require `meta.microgrid_id` to be set.
 - The minimum supported version of `matplotlib` is now `v3.9.2`.
 
 ## New Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "pvlib >= 0.13.0, < 0.14.0",
   "python-dotenv >= 0.21.0, < 1.2.0",
   "toml >= 0.10.2, < 0.11.0",
+  "marshmallow_dataclass >= 8.7.1, < 9",
   "plotly >= 6.0.0, < 6.4.0",
   "kaleido >= 0.2.1, < 1.2.0",
   "frequenz-client-reporting >= 0.19.0, < 0.20.0",

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -6,9 +6,10 @@
 import logging
 import re
 import tomllib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast, get_args
+
+from marshmallow_dataclass import dataclass
 
 _logger = logging.getLogger(__name__)
 

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -8,8 +8,9 @@ import re
 import tomllib
 from dataclasses import field
 from pathlib import Path
-from typing import Any, Literal, cast, get_args
+from typing import Any, ClassVar, Literal, Self, Type, cast, get_args
 
+from marshmallow import Schema
 from marshmallow_dataclass import dataclass
 
 _logger = logging.getLogger(__name__)
@@ -198,24 +199,6 @@ class MicrogridConfig:
     ctype: dict[str, ComponentTypeConfig] = field(default_factory=dict)
     """Mapping of component category types to ac power component config."""
 
-    def __init__(self, config_dict: dict[str, Any]) -> None:
-        """Initialize the microgrid configuration.
-
-        Args:
-            config_dict: Dictionary with component type as key and config as value.
-        """
-        self.meta = Metadata(**(config_dict.get("meta") or {}))
-
-        self.pv = config_dict.get("pv") or {}
-        self.wind = config_dict.get("wind") or {}
-        self.battery = config_dict.get("battery") or {}
-
-        self.ctype = {
-            ctype: ComponentTypeConfig(**cfg)
-            for ctype, cfg in config_dict.get("ctype", {}).items()
-            if ComponentTypeConfig.is_valid_type(ctype)
-        }
-
     def component_types(self) -> list[str]:
         """Get a list of all component types in the configuration."""
         return list(self.ctype.keys())
@@ -282,6 +265,67 @@ class MicrogridConfig:
 
         return formula
 
+    Schema: ClassVar[Type[Schema]] = Schema
+
+    @classmethod
+    def _load_table_entries(cls, data: dict[str, Any]) -> dict[str, Self]:
+        """Load microgrid configurations from table entries.
+
+        Args:
+            data: The loaded TOML data.
+
+        Returns:
+            A dict mapping microgrid IDs to MicrogridConfig instances.
+
+        Raises:
+            ValueError: If top-level keys are not numeric microgrid IDs
+                or if there is a microgrid ID mismatch.
+            TypeError: If microgrid data is not a dict.
+        """
+        if not all(str(k).isdigit() for k in data.keys()):
+            raise ValueError("All top-level keys must be numeric microgrid IDs.")
+
+        mgrids = {}
+        for mid, entry in data.items():
+            if not mid.isdigit():
+                raise ValueError(
+                    f"Table reader: Microgrid ID key must be numeric, got {mid}"
+                )
+            if not isinstance(entry, dict):
+                raise TypeError("Table reader: Each microgrid entry must be a dict")
+
+            mgrid = cls.Schema().load(entry)
+            if mgrid.meta is None or mgrid.meta.microgrid_id is None:
+                raise ValueError(
+                    "Table reader: Each microgrid entry must have a meta.microgrid_id"
+                )
+            if int(mgrid.meta.microgrid_id) != int(mid):
+                raise ValueError(
+                    f"Table reader: Microgrid ID mismatch: key {mid} != {mgrid.meta.microgrid_id}"
+                )
+
+            mgrids[mid] = mgrid
+
+        return mgrids
+
+    @classmethod
+    def load_from_file(cls, config_path: Path) -> dict[int, Self]:
+        """
+        Load and validate configuration settings from a TOML file.
+
+        Args:
+            config_path: the path to the TOML configuration file.
+
+        Returns:
+            A dict mapping microgrid IDs to MicrogridConfig instances.
+        """
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+
+        assert isinstance(data, dict)
+
+        return cls._load_table_entries(data)
+
     @staticmethod
     def load_configs(
         microgrid_config_files: str | Path | list[str | Path] | None = None,
@@ -340,14 +384,7 @@ class MicrogridConfig:
                 _logger.warning("Config path %s is not a file, skipping.", config_path)
                 continue
 
-            with config_path.open("rb") as f:
-                cfg_dict = tomllib.load(f)
-                for microgrid_id, mcfg in cfg_dict.items():
-                    _logger.debug(
-                        "Loading microgrid config for ID %s from %s",
-                        microgrid_id,
-                        config_path,
-                    )
-                    microgrid_configs[microgrid_id] = MicrogridConfig(mcfg)
+            mcfgs = MicrogridConfig.load_from_file(config_path)
+            microgrid_configs.update({str(key): value for key, value in mcfgs.items()})
 
         return microgrid_configs

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -160,20 +160,6 @@ class BatteryConfig:
     """Capacity of the battery in Wh."""
 
 
-@dataclass(frozen=True)
-class AssetsConfig:
-    """Configuration of the assets in a microgrid."""
-
-    pv: dict[str, PVConfig] | None = None
-    """Configuration of the PV system."""
-
-    wind: dict[str, WindConfig] | None = None
-    """Configuration of the wind turbines."""
-
-    battery: dict[str, BatteryConfig] | None = None
-    """Configuration of the batteries."""
-
-
 # pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Metadata:
@@ -211,8 +197,14 @@ class MicrogridConfig:
     meta: Metadata | None = None
     """Metadata of the microgrid."""
 
-    assets: AssetsConfig | None = None
-    """Configuration of the assets in the microgrid."""
+    pv: dict[str, PVConfig] | None = None
+    """Configuration of the PV system."""
+
+    wind: dict[str, WindConfig] | None = None
+    """Configuration of the wind turbines."""
+
+    battery: dict[str, BatteryConfig] | None = None
+    """Configuration of the batteries."""
 
     ctype: dict[str, ComponentTypeConfig] = field(default_factory=dict)
     """Mapping of component category types to ac power component config."""
@@ -225,11 +217,9 @@ class MicrogridConfig:
         """
         self.meta = Metadata(**(config_dict.get("meta") or {}))
 
-        self.assets = AssetsConfig(
-            pv=config_dict.get("pv") or {},
-            wind=config_dict.get("wind") or {},
-            battery=config_dict.get("battery") or {},
-        )
+        self.pv = config_dict.get("pv") or {}
+        self.wind = config_dict.get("wind") or {}
+        self.battery = config_dict.get("battery") or {}
 
         self.ctype = {
             ctype: ComponentTypeConfig(component_type=cast(ComponentType, ctype), **cfg)

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -207,13 +207,13 @@ class Metadata:
 class MicrogridConfig:
     """Configuration of a microgrid."""
 
-    _metadata: Metadata
+    meta: Metadata
     """Metadata of the microgrid."""
 
-    _assets_cfg: AssetsConfig
+    assets: AssetsConfig
     """Configuration of the assets in the microgrid."""
 
-    _component_types_cfg: dict[str, ComponentTypeConfig]
+    ctype: dict[str, ComponentTypeConfig]
     """Mapping of component category types to ac power component config."""
 
     def __init__(self, config_dict: dict[str, Any]) -> None:
@@ -222,33 +222,23 @@ class MicrogridConfig:
         Args:
             config_dict: Dictionary with component type as key and config as value.
         """
-        self._metadata = Metadata(**(config_dict.get("meta") or {}))
+        self.meta = Metadata(**(config_dict.get("meta") or {}))
 
-        self._assets_cfg = AssetsConfig(
+        self.assets = AssetsConfig(
             pv=config_dict.get("pv") or {},
             wind=config_dict.get("wind") or {},
             battery=config_dict.get("battery") or {},
         )
 
-        self._component_types_cfg = {
+        self.ctype = {
             ctype: ComponentTypeConfig(component_type=cast(ComponentType, ctype), **cfg)
             for ctype, cfg in config_dict.get("ctype", {}).items()
             if ComponentTypeConfig.is_valid_type(ctype)
         }
 
-    @property
-    def meta(self) -> Metadata:
-        """Return the metadata of the microgrid."""
-        return self._metadata
-
-    @property
-    def assets(self) -> AssetsConfig:
-        """Return the assets configuration of the microgrid."""
-        return self._assets_cfg
-
     def component_types(self) -> list[str]:
         """Get a list of all component types in the configuration."""
-        return list(self._component_types_cfg.keys())
+        return list(self.ctype.keys())
 
     def component_type_ids(
         self,
@@ -272,7 +262,7 @@ class MicrogridConfig:
             ValueError: If the component type is unknown.
             KeyError: If `component_category` is invalid.
         """
-        cfg = self._component_types_cfg.get(component_type)
+        cfg = self.ctype.get(component_type)
         if not cfg:
             raise ValueError(f"{component_type} not found in config.")
 
@@ -301,7 +291,7 @@ class MicrogridConfig:
         Raises:
             ValueError: If the component type is unknown or formula is missing.
         """
-        cfg = self._component_types_cfg.get(component_type)
+        cfg = self.ctype.get(component_type)
         if not cfg:
             raise ValueError(f"{component_type} not found in config.")
         if cfg.formula is None:

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -6,6 +6,7 @@
 import logging
 import re
 import tomllib
+from dataclasses import field
 from pathlib import Path
 from typing import Any, Literal, cast, get_args
 
@@ -207,13 +208,13 @@ class Metadata:
 class MicrogridConfig:
     """Configuration of a microgrid."""
 
-    meta: Metadata
+    meta: Metadata | None = None
     """Metadata of the microgrid."""
 
-    assets: AssetsConfig
+    assets: AssetsConfig | None = None
     """Configuration of the assets in the microgrid."""
 
-    ctype: dict[str, ComponentTypeConfig]
+    ctype: dict[str, ComponentTypeConfig] = field(default_factory=dict)
     """Mapping of component category types to ac power component config."""
 
     def __init__(self, config_dict: dict[str, Any]) -> None:

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -25,9 +25,6 @@ ComponentCategory = Literal["meter", "inverter", "component"]
 class ComponentTypeConfig:
     """Configuration of a microgrid component type."""
 
-    component_type: ComponentType
-    """Type of the component."""
-
     meter: list[int] | None = None
     """List of meter IDs for this component."""
 
@@ -47,12 +44,6 @@ class ComponentTypeConfig:
             self.formula["AC_ACTIVE_POWER"] = "+".join(
                 [f"#{cid}" for cid in self._default_cids()]
             )
-        if self.component_type == "battery" and "BATTERY_SOC_PCT" not in self.formula:
-            if self.component:
-                cids = self.component
-                form = "+".join([f"#{cid}" for cid in cids])
-                form = f"({form})/({len(cids)})"
-                self.formula["BATTERY_SOC_PCT"] = form
 
     def cids(self, metric: str = "") -> list[int]:
         """Get component IDs for this component.
@@ -76,9 +67,7 @@ class ComponentTypeConfig:
                 raise ValueError("Formula must be a dictionary.")
             formula = self.formula.get(metric)
             if not formula:
-                raise ValueError(
-                    f"{metric} does not have a formula for {self.component_type}"
-                )
+                raise ValueError(f"{metric} does not have a formula")
             # Extract component IDs from the formula which are given as e.g. #123
             pattern = r"#(\d+)"
             return [int(e) for e in re.findall(pattern, self.formula[metric])]
@@ -104,7 +93,7 @@ class ComponentTypeConfig:
         if self.component:
             return self.component
 
-        raise ValueError(f"No IDs available for {self.component_type}")
+        raise ValueError("No IDs available")
 
     @classmethod
     def is_valid_type(cls, ctype: str) -> bool:
@@ -222,7 +211,7 @@ class MicrogridConfig:
         self.battery = config_dict.get("battery") or {}
 
         self.ctype = {
-            ctype: ComponentTypeConfig(component_type=cast(ComponentType, ctype), **cfg)
+            ctype: ComponentTypeConfig(**cfg)
             for ctype, cfg in config_dict.get("ctype", {}).items()
             if ComponentTypeConfig.is_valid_type(ctype)
         }

--- a/src/frequenz/data/microgrid/config.py
+++ b/src/frequenz/data/microgrid/config.py
@@ -155,11 +155,11 @@ class BatteryConfig:
 class Metadata:
     """Metadata for a microgrid."""
 
+    microgrid_id: int
+    """ID of the microgrid."""
+
     name: str | None = None
     """Name of the microgrid."""
-
-    microgrid_id: int | None = None
-    """ID of the microgrid."""
 
     enterprise_id: int | None = None
     """Enterprise ID of the microgrid."""
@@ -184,7 +184,7 @@ class Metadata:
 class MicrogridConfig:
     """Configuration of a microgrid."""
 
-    meta: Metadata | None = None
+    meta: Metadata
     """Metadata of the microgrid."""
 
     pv: dict[str, PVConfig] | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@
 """Tests for the frequenz.lib.notebooks.config module."""
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
@@ -41,7 +41,8 @@ VALID_CONFIG: dict[str, dict[str, Any]] = {
 @pytest.fixture
 def valid_microgrid_config() -> MicrogridConfig:
     """Fixture to provide a valid MicrogridConfig instance."""
-    return MicrogridConfig(VALID_CONFIG["1"])
+    # pylint: disable=protected-access
+    return MicrogridConfig._load_table_entries(VALID_CONFIG)["1"]
 
 
 def test_is_valid_type() -> None:
@@ -64,10 +65,10 @@ def test_microgrid_config_init(valid_microgrid_config: MicrogridConfig) -> None:
     assert valid_microgrid_config.meta is not None
     assert valid_microgrid_config.meta.name == "Test Grid"
     pv_config = valid_microgrid_config.pv
-    if pv_config:
-        _assert_optional_field(
-            cast(dict[str, float], pv_config["PV1"]).get("peak_power"), 5000
-        )
+    assert pv_config is not None
+    pv_system = pv_config.get("PV1")
+    assert pv_system is not None
+    assert pv_system.peak_power == 5000
 
 
 def test_microgrid_config_component_types(
@@ -132,15 +133,18 @@ def test_load_configs(mocker: MockerFixture) -> None:
     assert "1" in configs
     assert configs["1"].meta is not None
     assert configs["1"].meta.name == "Test Grid"
+
     pv_config = configs["1"].pv
+    assert pv_config is not None
+    pv_system = pv_config.get("PV1")
+    assert pv_system is not None
+    assert pv_system.peak_power == 5000
+
     battery_config = configs["1"].battery
-    if pv_config and battery_config:
-        _assert_optional_field(
-            cast(dict[str, float], pv_config["PV1"]).get("peak_power"), 5000
-        )
-        _assert_optional_field(
-            cast(dict[str, float], battery_config["BAT1"]).get("capacity"), 10000
-        )
+    assert battery_config is not None
+    battery_system = battery_config.get("BAT1")
+    assert battery_system is not None
+    assert battery_system.capacity == 10000
 
 
 def _assert_optional_field(value: float | None, expected: float) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from frequenz.data.microgrid.config import ComponentTypeConfig
 
 VALID_CONFIG: dict[str, dict[str, Any]] = {
     "1": {
-        "meta": {"name": "Test Grid", "gid": 1},
+        "meta": {"name": "Test Grid", "gid": 1, "microgrid_id": 1},
         "ctype": {
             "pv": {"meter": [101, 102], "formula": {"AC_ACTIVE_POWER": "#12+#23"}},
             "battery": {
@@ -52,21 +52,18 @@ def test_is_valid_type() -> None:
 
 def test_component_type_config_cids() -> None:
     """Test the retrieval of component IDs for various configurations."""
-    config = ComponentTypeConfig(component_type="pv", meter=[1, 2, 3])
+    config = ComponentTypeConfig(inverter=[1, 2, 3])
     assert config.cids() == [1, 2, 3]
 
-    config = ComponentTypeConfig(component_type="battery", inverter=[4, 5])
+    config = ComponentTypeConfig(meter=[4, 5], inverter=[1, 2, 3])
     assert config.cids() == [4, 5]
-
-    with pytest.raises(ValueError):
-        config = ComponentTypeConfig(component_type="grid")
-        config.cids()
 
 
 def test_microgrid_config_init(valid_microgrid_config: MicrogridConfig) -> None:
     """Test initialisation of MicrogridConfig with valid configuration data."""
+    assert valid_microgrid_config.meta is not None
     assert valid_microgrid_config.meta.name == "Test Grid"
-    pv_config = valid_microgrid_config.assets.pv
+    pv_config = valid_microgrid_config.pv
     if pv_config:
         _assert_optional_field(
             cast(dict[str, float], pv_config["PV1"]).get("peak_power"), 5000
@@ -133,9 +130,10 @@ def test_load_configs(mocker: MockerFixture) -> None:
     configs = MicrogridConfig.load_configs(Path("mock_path.toml"))
 
     assert "1" in configs
+    assert configs["1"].meta is not None
     assert configs["1"].meta.name == "Test Grid"
-    pv_config = configs["1"].assets.pv
-    battery_config = configs["1"].assets.battery
+    pv_config = configs["1"].pv
+    battery_config = configs["1"].battery
     if pv_config and battery_config:
         _assert_optional_field(
             cast(dict[str, float], pv_config["PV1"]).get("peak_power"), 5000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,10 +112,10 @@ def test_microgrid_config_formula(valid_microgrid_config: MicrogridConfig) -> No
 def test_load_configs(mocker: MockerFixture) -> None:
     """Test loading configurations for multiple microgrids from mock TOML files."""
     toml_data = """
+    1.meta.microgrid_id = 1
     1.meta.name = "Test Grid"
     1.meta.gid = 1
     1.ctype.pv.meter = [101, 102]
-    1.ctype.pv.formula = "AC_ACTIVE_POWER"
     1.ctype.battery.inverter = [201, 202, 203]
     1.ctype.battery.component = [301, 302, 303, 304, 305, 306]
     1.pv.PV1.peak_power = 5000


### PR DESCRIPTION
Previously, microgrid configs were initialized by unpacking nested dictionaries. Now the class defines a marshmallow schema and uses it to deserialize toml data into valudated python objects.

Introduces a new `load_from_file` function to load multiple configs as dict from a single file. This is also used now in the existing function to load multiple files or directories.