### PR TITLE
feat: add default mapping loader function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@
 - Published a locale-aware `ColumnMapper` utility that reads the YAML schema so notebooks can seamlessly move between raw API headers, canonical identifiers, and localized display labels.
 - plot_time_series() can auto-pivot long-format inputs, honor a desired legend/trace order, and optionally fill selected traces while keeping Plotly colors consistent through a shared palette builder; also defaults to numeric columns only to avoid spurious traces (src/frequenz/lib/notebooks/reporting/plotter.py (lines 15-163)).
 - Added reusable long_to_wide() and build_color_map() helpers so notebooks can pivot categorical telemetry and reuse the canonical color scheme without duplicating logic (src/frequenz/lib/notebooks/reporting/utils/helpers.py (lines 216-311)).
+- Added a default mapping loading to the `ColumnMapper` utility function.
 
 ## Bug Fixes
 - `frequenz.lib.notebooks.reporting.utils.helpers.add_energy_flows()` now infers consumption totals from existing data when explicit consumption columns are missing, preventing inconsistent outputs in notebook pipelines that only provide grid and production inputs.

--- a/src/frequenz/lib/notebooks/reporting/utils/column_mapper.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/column_mapper.py
@@ -25,6 +25,7 @@ Examples:
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from importlib import resources
 from typing import Iterable, Mapping
 
 import pandas as pd
@@ -75,6 +76,9 @@ class ColumnMapper:  # pylint: disable=too-many-instance-attributes
         metadata={
             "doc": "Fallback locale to use when the preferred locale is unavailable in the schema.",
         },
+    )
+    _DEFAULT_RESOURCE = resources.files("frequenz.lib.notebooks.reporting").joinpath(
+        "schema_mapping.yaml"
     )
 
     # ---------- Construction ----------
@@ -152,6 +156,40 @@ class ColumnMapper:  # pylint: disable=too-many-instance-attributes
             locale=locale,
             fallback_locale=fallback_locale,
         )
+
+    @classmethod
+    def from_default(
+        cls,
+        *,
+        locale: str = "de",
+        fallback_locale: str = "en",
+        required: Iterable[str] | None = None,
+    ) -> ColumnMapper:
+        """Create an instance using the built-in default YAML resource.
+
+        Loads the default configuration file bundled with the package and
+        initializes the class using localized settings.
+
+        Args:
+            locale: Primary locale code for localized configuration values.
+                Defaults to "de".
+            fallback_locale: Secondary locale used if a key is missing in
+                the primary locale. Defaults to "en".
+            required: Optional list of keys that must be present in the
+                loaded configuration. If provided and any are missing,
+                an exception is raised.
+
+        Returns:
+            An initialized instance of the class populated from the
+            built-in default YAML resource.
+        """
+        with resources.as_file(cls._DEFAULT_RESOURCE) as yaml_path:
+            return cls.from_yaml(
+                str(yaml_path),
+                locale=locale,
+                fallback_locale=fallback_locale,
+                required=required,
+            )
 
     # ---------- Properties ----------
     @property


### PR DESCRIPTION
This PR adds a convenience method `from_default()` to the `ColumnMapper` class that loads column mapping configuration from a bundled default YAML resource file, eliminating the need for users to specify the file path explicitly.

This would allow the users to pick the default yaml file from the library in addition to specifying any other .yaml files