### PR TITLE
Add grid import function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@
 - plot_time_series() can auto-pivot long-format inputs, honor a desired legend/trace order, and optionally fill selected traces while keeping Plotly colors consistent through a shared palette builder; also defaults to numeric columns only to avoid spurious traces (src/frequenz/lib/notebooks/reporting/plotter.py (lines 15-163)).
 - Added reusable long_to_wide() and build_color_map() helpers so notebooks can pivot categorical telemetry and reuse the canonical color scheme without duplicating logic (src/frequenz/lib/notebooks/reporting/utils/helpers.py (lines 216-311)).
 - Added a default mapping loading to the `ColumnMapper` utility function.
+- Add `grid_consumption` function in the `reporting_metrics.py`.
 
 ## Bug Fixes
 - `frequenz.lib.notebooks.reporting.utils.helpers.add_energy_flows()` now infers consumption totals from existing data when explicit consumption columns are missing, preventing inconsistent outputs in notebook pipelines that only provide grid and production inputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,13 @@ dependencies = [
   "pvlib >= 0.13.0, < 0.14.0",
   "python-dotenv >= 0.21.0, < 1.3.0",
   "toml >= 0.10.2, < 0.11.0",
-  "marshmallow_dataclass >= 8.7.1, < 9",
+  "marshmallow-dataclass>=8.7.1,<9",
   "plotly >= 6.0.0, < 6.4.0",
   "kaleido >= 0.2.1, < 1.2.0",
   "frequenz-client-reporting >= 0.19.0, < 0.20.0",
   "frequenz-client-weather >= 0.2.3, < 0.3.0",
   "types-pyyaml>=6.0.12.20250915",
+  "marshmallow>=4.1.0,<5",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
+++ b/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
@@ -244,3 +244,54 @@ def consumption(
     result.name = "consumption"
 
     return result
+
+
+def grid_consumption(
+    grid: pd.Series | None,
+    production: pd.Series | None,
+    consumption: pd.Series | None,
+    battery: pd.Series | None,
+) -> pd.Series:
+    """Determine grid import using measured or derived series.
+
+    This function follows the PSC (Production-Storage-Consumption) convention:
+    - Production is positive when generating.
+    - Battery is positive when charging (consuming energy).
+    - Consumption is positive when consuming energy.
+
+    Prefers the measured grid series (positive import, negative export). When
+    unavailable, derives grid import from the remaining energy balance.
+
+    Args:
+        grid: Grid power series (positive import), or ``None``.
+        production: Production power series (PSC-convention), or ``None``.
+        consumption: Consumption power series (PSC-convention), or ``None``.
+        battery: Battery power (PSC-convention: charging positive), or ``None``.
+
+    Returns:
+        Series with non-negative grid import values.
+
+    Raises:
+        ValueError: If neither a grid series nor any of production,
+            consumption, or battery series are provided.
+    """
+    if grid is not None:
+        return grid.astype("float64").clip(lower=0)
+
+    # Ensure at least one other input is provided
+    if all(s is None for s in (production, consumption, battery)):
+        raise ValueError(
+            "Cannot compute grid_consumption because no grid, production, "
+            "consumption, or battery series were provided. "
+            "This function follows PSC conventions, so production and battery "
+            "must also follow those conventions."
+        )
+
+    prod = production.astype("float64") if production is not None else 0.0
+    cons = consumption.astype("float64") if consumption is not None else 0.0
+    batt = battery.astype("float64") if battery is not None else 0.0
+
+    inferred = cons + prod + batt
+
+    # We only want the import portion (≥ 0)
+    return inferred.clip(lower=0)  # type: ignore[union-attr]


### PR DESCRIPTION
Added grid import function in the reporting metrics to calculate the amount of electricity purchased from the grid. 

This would be used to calculate grid_import from the given production, consumption and battery columns.