### PR TITLE
Update wind component

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,21 +2,12 @@
 
 ## Summary
 
-This release syncs the reporting helpers with the latest schema and dependency requirements so that asset columns, component analyses, and timestamp handling all stay consistent with the data sources we consume.
 
 ## Upgrading
 
-- The pyproject lock now requires `pyyaml>=6.0.3` and `pytz>=2025.2`, so reinstall the dependencies to pick up the tighter YAML and timezone support.
-- Column names in exported energy reports have shifted: `grid_consumption` is now computed via the `grid` helper column before renaming, and battery data should be referenced as `battery_power_flow` rather than `battery_throughput`.
 
 ## New Features
 
-- Wind asset production is now fleshed out in the schema mapping (including localized display names) and is available to the overview builder and component analysis flows, alongside the existing PV and CHP columns.
-- Component analyses now apply the mapper renaming step after totals are summed, preventing columns from being renamed prematurely and ensuring the display names defined in `schema_mapping.yaml` are always respected.
 
 ## Bug Fixes
-
-- Notification deserialization now relies on `isinstance()` to guard against optional dataclass arguments, eliminating the brittle `type()` checks that occasionally crashed the signal service.
-- Peak-date computation now pulls the timestamp directly from the aggregated dataframe, coerces it to UTC, and formats it safely, so peak dates no longer break when indexes are strings or timezone-naive.
-- The grid column is only populated when it is missing to avoid re-creating `grid_consumption`, preventing duplicate columns during the energy-flow aggregation.
-- Schema mappings for CHP and wind outputs have been aligned with the latest raw column tags, and all production display names now use the new hyphenated nomenclature (`PV-Production`, `CHP-Production`, `Wind-Production`).
+- Fixed wind components in the energy_report_df and aggregating metrics.

--- a/src/frequenz/lib/notebooks/reporting/data_processing.py
+++ b/src/frequenz/lib/notebooks/reporting/data_processing.py
@@ -76,7 +76,7 @@ def create_energy_report_df(
     # Add Energy flow columns
     energy_report_df = add_energy_flows(
         energy_report_df,
-        production_cols=["pv", "chp"],
+        production_cols=["pv", "chp", "wind"],
         consumption_cols=["consumption"],
         grid_cols=["grid"],
         battery_cols=["battery"],
@@ -107,6 +107,7 @@ def create_energy_report_df(
         column_pv="pv",
         column_chp="chp",
         column_ev="ev",
+        column_wind="wind",
     )
 
     # Determine relevant columns based on component types

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -279,31 +279,41 @@ def get_energy_report_columns(
     # Map component types to the columns they enable
     component_column_map = {
         "battery": ["battery_power_flow"],
-        "pv": [
-            "pv_asset_production",
-            "production_self_use",
-            "grid_feed_in",
-        ],
+        "pv": ["pv_asset_production"],
         "chp": ["chp_asset_production"],
+        "ev": ["ev_asset_production"],
     }
 
-    # Define columns that require both PV and Battery
-    pv_battery_cols = [
-        "production_excess_in_bat",
+    production_components = set(component_column_map.keys()) - {"battery"}
+
+    # Columns that should be included if ANY production component exists
+    universal_production_cols = [
+        "production_self_use",
+        "grid_feed_in",
         "production_self_share",
     ]
 
-    # Add component-specific columns
-    for component, columns in component_column_map.items():
-        if component in component_types:
-            energy_report_df_cols.extend(columns)
+    # Columns available ONLY when battery exists
+    battery_dependent_cols = [
+        "production_excess_in_bat",
+    ]
 
-    # Add combined PV + Battery columns
-    if (
-        any(c in component_types for c in ["pv", "chp", "wind", "ev"])
-        and "battery" in component_types
-    ):
-        energy_report_df_cols.extend(pv_battery_cols)
+    # Check if any production component is present
+    has_production = any(comp in production_components for comp in component_types)
+    has_battery = "battery" in component_types
+
+    # Add the universal production columns ONLY if production exists
+    if has_production:
+        energy_report_df_cols.extend(universal_production_cols)
+
+    # Add battery-dependent production columns
+    if has_battery:
+        energy_report_df_cols.extend(battery_dependent_cols)
+
+    # Add component-specific columns
+    for comp in component_types:
+        if comp in component_column_map:
+            energy_report_df_cols.extend(component_column_map[comp])
 
     return energy_report_df_cols
 

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -191,7 +191,7 @@ def convert_timezone(
     return ts.dt.tz_convert(target_tz)
 
 
-# pylint: disable=too-many-arguments, too-many-positional-arguments
+# pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals
 def label_component_columns(
     df: pd.DataFrame,
     mcfg: MicrogridConfig,
@@ -199,6 +199,7 @@ def label_component_columns(
     column_pv: str = "pv",
     column_chp: str = "chp",
     column_ev: str = "ev",
+    column_wind: str = "wind",
 ) -> tuple[pd.DataFrame, list[str]]:
     """Rename numeric single-component columns to labeled names.
 
@@ -213,7 +214,9 @@ def label_component_columns(
         column_battery: Key name for battery component type.
         column_pv: Key name for PV component type.
         column_chp: Key name for CHP component type.
-        column_ev: Key name for EV component type
+        column_ev: Key name for EV component type.
+        column_wind: Key name for wind component type.
+
     Returns:
         Tuple containing the renamed DataFrame and the list of applied labels
     """
@@ -233,6 +236,7 @@ def label_component_columns(
     pv_ids = ids_if_available(column_pv)
     chp_ids = ids_if_available(column_chp)
     ev_ids = ids_if_available(column_ev)
+    wind_ids = ids_if_available(column_wind)
 
     rename: dict[str, str] = {}
     rename.update(
@@ -250,6 +254,13 @@ def label_component_columns(
     )
     rename.update(
         {c: f"{column_chp.upper()} #{c}" for c in single_components if c in chp_ids}
+    )
+    rename.update(
+        {
+            c: f"{column_wind.capitalize()} #{c}"
+            for c in single_components
+            if c in wind_ids
+        }
     )
 
     return df.rename(columns=rename), list(rename.values())
@@ -282,6 +293,7 @@ def get_energy_report_columns(
         "pv": ["pv_asset_production"],
         "chp": ["chp_asset_production"],
         "ev": ["ev_asset_production"],
+        "wind": ["wind_asset_production"],
     }
 
     production_components = set(component_column_map.keys()) - {"battery"}


### PR DESCRIPTION
This pull request adds support for wind components to the energy reporting system, enabling wind power generation to be tracked and displayed alongside other production components like PV and CHP.

### Key Changes
- Added column_wind parameter to label_component_columns function to enable renaming wind component IDs
- Included "wind" in the production columns for energy flow calculations
- Added wind component to the energy report column mapping with support for universal production columns
