### PR TITLE
Fill missing aggregated values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fill missing values in aggregated component columns.

--- a/src/frequenz/lib/notebooks/reporting/data_processing.py
+++ b/src/frequenz/lib/notebooks/reporting/data_processing.py
@@ -27,8 +27,10 @@ from frequenz.gridpool import MicrogridConfig
 
 from frequenz.lib.notebooks.reporting.utils.column_mapper import ColumnMapper
 from frequenz.lib.notebooks.reporting.utils.helpers import (
+    AggregatedComponentConfig,
     add_energy_flows,
     convert_timezone,
+    fill_aggregated_component_columns,
     get_energy_report_columns,
     label_component_columns,
 )
@@ -43,6 +45,8 @@ def create_energy_report_df(
     *,
     tz_name: str = "Europe/Berlin",
     assume_tz: str = "UTC",
+    fill_missing_values: bool = True,
+    aggregated_component_config: AggregatedComponentConfig | None = None,
 ) -> pd.DataFrame:
     """Create a normalized Energy Report DataFrame with selected columns.
 
@@ -59,6 +63,11 @@ def create_energy_report_df(
         mapper: Column Mapper object to standardize the column names.
         tz_name: Target timezone name for timestamp conversion (default: "Europe/Berlin").
         assume_tz: Timezone to assume for naive datetimes before conversion (default: "UTC").
+        fill_missing_values: Whether to fill missing aggregate component columns
+                from per-component sums (default: True).
+        aggregated_component_config: Optional mapping of component types to aggregated
+            column metadata used when filling missing aggregates. Defaults to the shared
+            `DEFAULT_AGGREGATED_COMPONENT_CONFIG`.
 
     Returns:
         The Energy Report DataFrame with standardized and selected columns.
@@ -117,4 +126,13 @@ def create_energy_report_df(
 
     # Select only the relevant columns
     energy_report_df = energy_report_df[energy_report_df_cols]
+
+    if fill_missing_values:
+        # Fill in missing aggregate component columns from per-component sums
+        energy_report_df = fill_aggregated_component_columns(
+            energy_report_df,
+            component_types,
+            aggregated_component_config,
+        )
+
     return energy_report_df

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import warnings
 from datetime import date, datetime, time
-from typing import Any, Literal, cast
+from typing import Any, Literal, Mapping, cast
 
 import matplotlib.colors as mcolors
 import pandas as pd
@@ -58,6 +58,16 @@ from frequenz.lib.notebooks.reporting.metrics.reporting_metrics import (
     production_self_consumption,
     production_self_share,
 )
+
+AggregatedComponentConfig = Mapping[str, tuple[str, str]]
+
+DEFAULT_AGGREGATED_COMPONENT_CONFIG: AggregatedComponentConfig = {
+    "battery": ("battery_power_flow", "Battery #"),
+    "pv": ("pv_asset_production", "PV #"),
+    "chp": ("chp_asset_production", "CHP #"),
+    "ev": ("ev_asset_production", "EV #"),
+    "wind": ("wind_asset_production", "Wind #"),
+}
 
 
 def _get_numeric_series(df: pd.DataFrame, col: str | None) -> pd.Series:
@@ -639,3 +649,45 @@ def build_color_map(
                 break
 
     return final
+
+
+def fill_aggregated_component_columns(
+    df: pd.DataFrame,
+    component_types: list[str],
+    config: AggregatedComponentConfig | None = None,
+) -> pd.DataFrame:
+    """Populate missing aggregate columns by summing labeled component columns.
+
+    Args:
+        df: Input DataFrame potentially containing aggregated component columns
+            (e.g., "battery_power_flow") and labeled individual component columns
+            (e.g., "Battery #1", "Battery #2").
+        component_types: List of component types to consider for aggregation
+            (e.g., ["battery", "pv"]).
+
+        config: Mapping of component types to tuples containing the aggregated
+            column name and the prefix used to identify individual component
+            columns.
+
+    Returns:
+        DataFrame with missing aggregated component columns filled in by summing
+        the corresponding individual component columns.
+    """
+    config = config or DEFAULT_AGGREGATED_COMPONENT_CONFIG
+    normalized_types = {comp.lower() for comp in component_types}
+
+    for comp_type, (agg_col, prefix) in config.items():
+        if comp_type not in normalized_types or agg_col not in df.columns:
+            continue
+
+        component_cols = [col for col in df.columns if col.startswith(prefix)]
+
+        # Only proceed if there are components to sum and missing values to fill
+        if component_cols and df[agg_col].isna().any():
+            # min_count=1 ensures all-NaN rows stay NaN instead of becoming 0
+            summed = df[component_cols].sum(axis=1, skipna=True, min_count=1)
+
+            # Fill only the holes
+            df[agg_col] = df[agg_col].fillna(summed)
+
+    return df

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,6 +21,7 @@ from frequenz.lib.notebooks.reporting.utils.helpers import (
     _sum_cols,
     build_color_map,
     convert_timezone,
+    fill_aggregated_component_columns,
     fmt_to_de_system,
     label_component_columns,
     long_to_wide,
@@ -196,6 +197,66 @@ def test_long_to_wide_pivots_and_adds_sum_column() -> None:
         ),
     )
     assert_frame_equal(wide, expected)
+
+
+def test_fill_aggregated_component_columns_backfills_missing_summaries() -> None:
+    """Aggregate columns are filled only where NaNs exist via per-component sums."""
+    df = pd.DataFrame(
+        {
+            "battery_power_flow": [0.0, float("nan"), 5.0],
+            "Battery #1": [1.0, 2.0, 2.5],
+            "Battery #2": [3.0, 4.0, 2.5],
+            "pv_asset_production": [float("nan"), float("nan"), 1.0],
+            "PV #1": [0.5, 0.75, 0.3],
+            "PV #2": [0.5, 0.25, 0.0],
+        }
+    )
+
+    result = fill_aggregated_component_columns(
+        df.copy(), component_types=["battery", "pv"]
+    )
+
+    assert result["battery_power_flow"].tolist() == [0.0, 6.0, 5.0]
+    assert result["pv_asset_production"].tolist() == [1.0, 1.0, 1.0]
+
+
+def test_fill_aggregated_component_columns_respects_component_filter() -> None:
+    """Only requested component types trigger aggregation fill-ins."""
+    df = pd.DataFrame(
+        {
+            "battery_power_flow": [0.0, float("nan")],
+            "Battery #1": [1.0, 2.0],
+            "Battery #2": [3.0, 4.0],
+            "pv_asset_production": [float("nan"), float("nan")],
+            "PV #1": [0.5, 0.75],
+            "PV #2": [0.5, 0.25],
+        }
+    )
+
+    result = fill_aggregated_component_columns(df.copy(), component_types=["battery"])
+
+    assert result["pv_asset_production"].iloc[:2].isna().all()
+
+
+def test_fill_aggregated_component_columns_accepts_custom_config() -> None:
+    """An external config mapping can drive aggregation of bespoke components."""
+    df = pd.DataFrame(
+        {
+            "custom_power": [float("nan"), 4.0],
+            "Custom #1": [1.0, 2.0],
+            "Custom #2": [2.0, 3.0],
+        }
+    )
+
+    config = {"custom": ("custom_power", "Custom #")}
+
+    result = fill_aggregated_component_columns(
+        df.copy(),
+        component_types=["custom"],
+        config=config,
+    )
+
+    assert result["custom_power"].tolist() == [3.0, 4.0]
 
 
 def test_long_to_wide_custom_sum_column_name() -> None:


### PR DESCRIPTION
This pull request adds functionality to fill missing values in aggregated component columns by summing their corresponding individual component data. The implementation automatically backfills NaN values in aggregate columns (e.g., battery_power_flow, pv_asset_production) by computing sums from labeled component columns (e.g., Battery #1, PV #1).

Key changes:

- Introduces fill_aggregated_component_columns() helper function with configurable component type filtering
- Integrates the filling logic into the energy report DataFrame creation pipeline with an optional flag
- Adds comprehensive test coverage for both basic filling behavior and component type filtering