### PR TITLE
Fix grid consumption aggregate metrics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,3 +16,4 @@
 ## Bug Fixes
 
 - Fill missing values in aggregated component columns.
+- Update aggregate metrics to have only positive values in grid consumption.

--- a/src/frequenz/lib/notebooks/reporting/utils/reporting_nb_functions.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/reporting_nb_functions.py
@@ -557,6 +557,11 @@ def aggregate_metrics(  # pylint: disable=too-many-locals
     for col_name, result_key in metric_columns.items():
         # Safely get column (or Series of zeros if missing)
         series = energy_report_df.get(col_name, zeros)
+
+        # Clip grid consumption to non-negative values to avoid negative grid feed-in values
+        if col_name == "grid_consumption":
+            series = series.clip(lower=0)
+
         # Calculate energy sum (Power * hours_factor)
         results[result_key] = (series * hours_factor).sum()
 


### PR DESCRIPTION
This PR updates the aggregate_metrics function to clip grid consumption values to non-negative values before calculating the grid consumption sum. The change prevents negative grid consumption values (which represent grid feed-in) from being included in the grid consumption aggregate metric.