### PR TITLE
Fix grid feed in

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,4 @@
 ## Bug Fixes
 - Fill missing values in aggregated component columns.
 - Update aggregate metrics to have only positive values in grid consumption.
+- Update grid feed-in metrics to first include negative values from grid column and simplify the grid feed-in logic.

--- a/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
+++ b/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
@@ -99,34 +99,48 @@ def production_excess_in_bat(
 
 
 def grid_feed_in(
-    production: pd.Series,
-    consumption: pd.Series,
-    battery: pd.Series,
-    production_is_positive: bool = False,
+    production: pd.Series | None,
+    consumption: pd.Series | None,
+    battery: pd.Series | None,
+    grid: pd.Series | None,
 ) -> pd.Series:
-    """Calculate the portion of excess production fed into the grid.
+    """Determine grid feed-in using measured or derived series.
 
-    Subtracts the amount of excess energy stored in the battery from the total
-    production surplus to determine how much is exported to the grid.
+    Prefers the measured grid series (negative export). When unavailable,
+    derives grid feed-in from the remaining energy balance.
 
     Args:
-        production: Series of production values (e.g., kW or MW).
-        consumption: Series of consumption values (same units as `production`).
-        battery: Series representing the battery's available
-            charging capacity.
-        production_is_positive: Whether production values are already positive. If False,
-            `production` is inverted before clipping.
+        production: Production power series (PSC-convention), or ``None``.
+        consumption: Consumption power series (PSC-convention), or ``None``.
+        battery: Battery power (PSC-convention: charging positive), or ``None``.
+        grid: Grid power series (negative export), or ``None``.
 
     Returns:
         A Series representing power or energy fed into the grid (≥ 0).
+
+    Raises:
+        ValueError: If no valid series are provided.
     """
-    production_excess_series = production_excess(
-        production, consumption, production_is_positive=production_is_positive
-    )
-    battery_series = production_excess_in_bat(
-        production, consumption, battery, production_is_positive=production_is_positive
-    )
-    return (production_excess_series - battery_series).clip(lower=0)
+    if grid is not None:
+        # If grid is provided, use it to determine feed-in.
+        # Grid feed-in is the negative values recorded in grid.
+        return grid.astype("float64").clip(upper=0).abs()
+
+    if all(s is None for s in (production, consumption, battery)):
+        raise ValueError(
+            "Cannot compute grid_feed_in because no grid, production, "
+            "consumption, or battery series were provided. "
+            "This function follows PSC conventions, so production and battery "
+            "must also follow those conventions."
+        )
+
+    prod = production.astype("float64") if production is not None else 0.0
+    cons = consumption.astype("float64") if consumption is not None else 0.0
+    batt = battery.astype("float64") if battery is not None else 0.0
+
+    inferred = cons + prod + batt
+
+    return inferred.clip(upper=0).abs()  # type: ignore[union-attr]
 
 
 def production_self_consumption(

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -453,10 +453,11 @@ def add_energy_flows(
 
     # Split excess into battery vs. grid
     df_flows["grid_feed_in"] = grid_feed_in(
-        df_flows["production_total"],
+        # To convert positive production back to PSC format (where production is negative)
+        df_flows["production_total"] * -1,
         df_flows["consumption_total"],
-        battery=battery_charge_series,
-        production_is_positive=True,
+        battery=battery_power_series,
+        grid=grid_power_series if resolved_grid_cols else None,
     )
 
     # If no production columns exist, set self-consumption metrics to zero

--- a/tests/test_reporting_metrics.py
+++ b/tests/test_reporting_metrics.py
@@ -46,15 +46,23 @@ def test_production_excess_in_bat_respects_battery_limits() -> None:
     assert_series_equal(result, expected)
 
 
-def test_grid_feed_in_excludes_energy_stored_in_battery() -> None:
-    """Grid feed-in equals production surplus minus what is stored in the battery."""
+def test_grid_feed_in_prefers_measured_grid_and_infers_when_missing() -> None:
+    """Measured grid export is used; otherwise it is inferred from PSC inputs."""
     production = pd.Series([-8, -3], index=pd.RangeIndex(2))
     consumption = pd.Series([2, 1], index=production.index)
     battery = pd.Series([5, 10], index=production.index)
 
-    result = metrics.grid_feed_in(production, consumption, battery)
-    expected = pd.Series([1.0, 0.0], index=production.index)
-    assert_series_equal(result, expected)
+    grid = pd.Series([-4, 2], index=production.index)
+    expected_measured = pd.Series([4.0, 0.0], index=production.index)
+    measured = metrics.grid_feed_in(production, consumption, battery, grid=grid)
+    assert_series_equal(measured, expected_measured)
+
+    inferred = metrics.grid_feed_in(production, consumption, battery, grid=None)
+    expected_inferred = pd.Series([1.0, 0.0], index=production.index)
+    assert_series_equal(inferred, expected_inferred)
+
+    with pytest.raises(ValueError):
+        metrics.grid_feed_in(None, None, None, grid=None)
 
 
 def test_production_self_consumption_warns_on_negative_values() -> None:


### PR DESCRIPTION
Aligned grid feed‑in computation with grid consumption by prioritizing measured grid export (negative values) when available, and deriving feed‑in as the export portion of inferred grid balance otherwise.

- Update grid_feed_in() to use measured grid export when a grid series is provided, otherwise infer export from the energy balance.
- Rewire add_energy_flows() to compute grid_feed_in using PSC-style inputs and (optionally) the measured grid series.