### PR TITLE
Fix asset opt nb

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,5 +13,5 @@
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
-
+- Update the asset optimization notebook with the correct api keys.
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
@@ -10,8 +10,9 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 from dotenv import load_dotenv
+from frequenz.gridpool import MicrogridConfig
 
-from frequenz.data.microgrid import MicrogridConfig, MicrogridData
+from frequenz.data.microgrid import MicrogridData
 
 _logger = logging.getLogger(__name__)
 
@@ -34,8 +35,8 @@ def init_microgrid_data(
         load_dotenv(dotenv_path=dotenv_path)
 
     service_address = os.environ["REPORTING_API_URL"]
-    api_key = os.environ["REPORTING_API_KEY"]
-    api_secret = os.environ["REPORTING_API_SECRET"]
+    api_key = os.environ["API_KEY"]
+    api_secret = os.environ["API_SECRET"]
 
     mcfg = MicrogridConfig.load_configs(
         microgrid_config_dir=microgrid_config_dir,


### PR DESCRIPTION
Updates the asset optimization reporting notebook helper to use a different MicrogridConfig import and to read API credentials from updated environment variable names.

Changes:

- Import MicrogridConfig from frequenz.gridpool instead of frequenz.data.microgrid.
- Read credentials from API_KEY / API_SECRET instead of REPORTING_API_KEY / REPORTING_API_SECRET.