### PR TITLE
Fix state analysis notebook with new electrical component enums  If

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,18 +2,16 @@
 
 ## Summary
 
-This release updates the asset-optimization reporting visuals to Plotly, improves
-interactivity and styling, and refactors data preparation for reuse.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- Asset-optimization plotting now returns Plotly figures (instead of matplotlib).
-  Update any downstream code that expects matplotlib `Axes` objects.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- Plotly-based asset-optimization charts with interactive hover, range sliders,
-  and improved styling (white background, borders, legend layout).
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
-- Update the asset optimization notebook with the correct api keys.
+
+Fix state analysis to support new `ElectricalComponent*Code` enums and diagnostic code handling.

--- a/src/frequenz/lib/notebooks/reporting/state_analysis.py
+++ b/src/frequenz/lib/notebooks/reporting/state_analysis.py
@@ -54,13 +54,15 @@ async def fetch_and_extract_state_durations(
         end_time: The end date and time for the period.
         resampling_period: The period for resampling the data. If None, data
             will be returned in its original resolution.
-        alert_states: List of ComponentStateCode names that should trigger an alert.
+        alert_states: List of ElectricalComponentStateCode that should trigger
+            an alert.
         include_warnings: Whether to include warning states in the alert records.
 
     Returns:
-        A tuple containing:
-            - A list of StateRecord instances representing the state changes.
-            - A list of StateRecord instances that match the alert criteria.
+        A tuple containing two lists of StateRecord instances:
+            1. All state records representing the state changes.
+            2. Only the alert records that match the specified alert states and
+                warning inclusion criteria.
     """
     samples = await _fetch_component_data(
         client=client,
@@ -246,8 +248,10 @@ def _group_samples_by_component(
         include_warnings: Whether to include warning states in the alert records.
 
     Returns:
-        A dictionary where keys are tuples of (microgrid_id, component_id) and values
-        are dictionaries with metric names as keys and lists of MetricSample as values.
+        A nested dictionary where the first key is a tuple of
+        (microgrid_id, component_id), and the value is another dictionary with
+        keys "state", "error", optionally "warning", mapping to lists of
+        MetricSample instances.
     """
     alert_metrics = {"state", "error"}
     if include_warnings:
@@ -267,7 +271,7 @@ def _resolve_enum_name(
     value: int,
     enum_class: type[ElectricalComponentStateCode | ElectricalComponentDiagnosticCode],
 ) -> str:
-    """Resolve the name of an enum member from its integer value.
+    """Resolve the name of an enum member.
 
     Args:
         value: The integer value of the enum member to resolve.
@@ -290,7 +294,8 @@ def _filter_alerts(
 
     Args:
         all_states: List of all state records.
-        alert_states: List of ComponentStateCode names that should trigger an alert.
+        alert_states: List of ElectricalComponentStateCode that should trigger
+            an alert.
         include_warnings: Whether to include warning states in the alert records.
 
     Returns:

--- a/src/frequenz/lib/notebooks/reporting/state_analysis.py
+++ b/src/frequenz/lib/notebooks/reporting/state_analysis.py
@@ -5,6 +5,8 @@
 
 import logging
 from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Protocol, TypeVar, cast
 
 from frequenz.client.common.metrics import Metric
 from frequenz.client.common.microgrid.electrical_components import (
@@ -17,6 +19,14 @@ from frequenz.client.reporting._types import MetricSample
 from ._state_records import StateRecord
 
 _logger = logging.getLogger(__name__)
+
+E_co = TypeVar("E_co", bound=Enum, covariant=True)
+
+
+class HasDiagnosticCode(Protocol[E_co]):
+    """Protocol for error/warning values that have a diagnostic code."""
+
+    diagnostic_code: int
 
 
 # pylint: disable-next=too-many-arguments
@@ -104,6 +114,9 @@ def _process_sample_group(
         microgrid_id: ID of the microgrid.
         component_id: ID of the component.
         samples_by_metric: Dict with keys "state", "error", optionally "warning".
+            Note: MetricSample.value Upstream annotation is too narrow (`float`
+            only); actual values may be float | int | objects. Therefore, we need
+            to cast to the expected types to satisfy the type checker.
 
     Returns:
         A list of StateRecord instances representing the state changes and
@@ -114,12 +127,14 @@ def _process_sample_group(
     warning_by_ts = {s.timestamp: s for s in samples_by_metric.get("warning", [])}
 
     records: list[StateRecord] = []
-    state_val = error_val = warning_val = None
+    state_val: int | None = None
+    error_val: HasDiagnosticCode[Any] | None = None
+    warning_val: HasDiagnosticCode[Any] | None = None
     state_start = error_start = warning_start = None
 
     def emit(
         metric: str,
-        val: float,
+        val: int,
         start: datetime | None,
         end: datetime | None,
         enum_class: type[
@@ -145,7 +160,7 @@ def _process_sample_group(
         if sample.value != state_val:
             if state_val is not None:
                 emit("state", state_val, state_start, ts, ElectricalComponentStateCode)
-            state_val = sample.value
+            state_val = cast(int, sample.value)
             state_start = ts
 
             # Close error/warning if exiting ERROR
@@ -172,7 +187,7 @@ def _process_sample_group(
         # While in ERROR
         if state_val == ElectricalComponentStateCode.ERROR.value:
             if ts in error_by_ts:
-                new_err = error_by_ts[ts].value
+                new_err = cast(HasDiagnosticCode[Any], error_by_ts[ts].value)
                 if new_err != error_val:
                     if error_val is not None:
                         emit(
@@ -186,7 +201,7 @@ def _process_sample_group(
                     error_start = ts
 
             if ts in warning_by_ts:
-                new_warn = warning_by_ts[ts].value
+                new_warn = cast(HasDiagnosticCode[Any], warning_by_ts[ts].value)
                 if new_warn != warning_val:
                     if warning_val is not None:
                         emit(
@@ -249,13 +264,13 @@ def _group_samples_by_component(
 
 
 def _resolve_enum_name(
-    value: float,
+    value: int,
     enum_class: type[ElectricalComponentStateCode | ElectricalComponentDiagnosticCode],
 ) -> str:
     """Resolve the name of an enum member from its integer value.
 
     Args:
-        value: The integer value of the enum.
+        value: The integer value of the enum member to resolve.
         enum_class: The enum class to convert the value to.
 
     Returns:

--- a/src/frequenz/lib/notebooks/reporting/state_analysis.py
+++ b/src/frequenz/lib/notebooks/reporting/state_analysis.py
@@ -13,6 +13,7 @@ from frequenz.client.common.microgrid.electrical_components import (
     ElectricalComponentDiagnosticCode,
     ElectricalComponentStateCode,
 )
+from frequenz.client.common.proto import enum_from_proto
 from frequenz.client.reporting import ReportingApiClient
 from frequenz.client.reporting._types import MetricSample
 
@@ -278,10 +279,9 @@ def _resolve_enum_name(
         enum_class: The enum class to convert the value to.
 
     Returns:
-        The name of the enum member if it exists, otherwise if the value is invalid,
-        the enum class will return a default value (e.g., "UNSPECIFIED").
+        The name of the enum member corresponding to the given value.
     """
-    result = enum_class.from_proto(value)  # type: ignore[arg-type]
+    result = enum_from_proto(value, enum_class, allow_invalid=False)
     return result.name
 
 

--- a/src/frequenz/lib/notebooks/reporting/state_analysis.py
+++ b/src/frequenz/lib/notebooks/reporting/state_analysis.py
@@ -7,9 +7,9 @@ import logging
 from datetime import datetime, timedelta
 
 from frequenz.client.common.metrics import Metric
-from frequenz.client.common.microgrid.components import (
-    ComponentErrorCode,
-    ComponentStateCode,
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentDiagnosticCode,
+    ElectricalComponentStateCode,
 )
 from frequenz.client.reporting import ReportingApiClient
 from frequenz.client.reporting._types import MetricSample
@@ -28,7 +28,7 @@ async def fetch_and_extract_state_durations(
     start_time: datetime,
     end_time: datetime,
     resampling_period: timedelta | None,
-    alert_states: list[ComponentStateCode],
+    alert_states: list[ElectricalComponentStateCode],
     include_warnings: bool = True,
 ) -> tuple[list[StateRecord], list[StateRecord]]:
     """Fetch data using the Reporting API and extract state durations and alert records.
@@ -122,7 +122,9 @@ def _process_sample_group(
         val: float,
         start: datetime | None,
         end: datetime | None,
-        enum_class: type[ComponentStateCode | ComponentErrorCode],
+        enum_class: type[
+            ElectricalComponentStateCode | ElectricalComponentDiagnosticCode
+        ],
     ) -> None:
         """Emit a state record."""
         records.append(
@@ -142,26 +144,44 @@ def _process_sample_group(
         # State change
         if sample.value != state_val:
             if state_val is not None:
-                emit("state", state_val, state_start, ts, ComponentStateCode)
+                emit("state", state_val, state_start, ts, ElectricalComponentStateCode)
             state_val = sample.value
             state_start = ts
 
             # Close error/warning if exiting ERROR
-            if state_val != ComponentStateCode.ERROR.value:
+            if state_val != ElectricalComponentStateCode.ERROR.value:
                 if error_val is not None:
-                    emit("error", error_val, error_start, ts, ComponentErrorCode)
+                    emit(
+                        "error",
+                        error_val.diagnostic_code,
+                        error_start,
+                        ts,
+                        ElectricalComponentDiagnosticCode,
+                    )
                     error_val = error_start = None
                 if warning_val is not None:
-                    emit("warning", warning_val, warning_start, ts, ComponentErrorCode)
+                    emit(
+                        "warning",
+                        warning_val.diagnostic_code,
+                        warning_start,
+                        ts,
+                        ElectricalComponentDiagnosticCode,
+                    )
                     warning_val = warning_start = None
 
         # While in ERROR
-        if state_val == ComponentStateCode.ERROR.value:
+        if state_val == ElectricalComponentStateCode.ERROR.value:
             if ts in error_by_ts:
                 new_err = error_by_ts[ts].value
                 if new_err != error_val:
                     if error_val is not None:
-                        emit("error", error_val, error_start, ts, ComponentErrorCode)
+                        emit(
+                            "error",
+                            error_val.diagnostic_code,
+                            error_start,
+                            ts,
+                            ElectricalComponentDiagnosticCode,
+                        )
                     error_val = new_err
                     error_start = ts
 
@@ -171,21 +191,33 @@ def _process_sample_group(
                     if warning_val is not None:
                         emit(
                             "warning",
-                            warning_val,
+                            warning_val.diagnostic_code,
                             warning_start,
                             ts,
-                            ComponentErrorCode,
+                            ElectricalComponentDiagnosticCode,
                         )
                     warning_val = new_warn
                     warning_start = ts
 
     if state_val is not None:
-        emit("state", state_val, state_start, None, ComponentStateCode)
-    if state_val == ComponentStateCode.ERROR.value:
+        emit("state", state_val, state_start, None, ElectricalComponentStateCode)
+    if state_val == ElectricalComponentStateCode.ERROR.value:
         if error_val is not None:
-            emit("error", error_val, error_start, None, ComponentErrorCode)
+            emit(
+                "error",
+                error_val.diagnostic_code,
+                error_start,
+                None,
+                ElectricalComponentDiagnosticCode,
+            )
         if warning_val is not None:
-            emit("warning", warning_val, warning_start, None, ComponentErrorCode)
+            emit(
+                "warning",
+                warning_val.diagnostic_code,
+                warning_start,
+                None,
+                ElectricalComponentDiagnosticCode,
+            )
     return records
 
 
@@ -217,7 +249,8 @@ def _group_samples_by_component(
 
 
 def _resolve_enum_name(
-    value: float, enum_class: type[ComponentStateCode | ComponentErrorCode]
+    value: float,
+    enum_class: type[ElectricalComponentStateCode | ElectricalComponentDiagnosticCode],
 ) -> str:
     """Resolve the name of an enum member from its integer value.
 
@@ -229,13 +262,13 @@ def _resolve_enum_name(
         The name of the enum member if it exists, otherwise if the value is invalid,
         the enum class will return a default value (e.g., "UNSPECIFIED").
     """
-    result = enum_class.from_proto(int(value))  # type: ignore[arg-type]
+    result = enum_class.from_proto(value)  # type: ignore[arg-type]
     return result.name
 
 
 def _filter_alerts(
     all_states: list[StateRecord],
-    alert_states: list[ComponentStateCode],
+    alert_states: list[ElectricalComponentStateCode],
     include_warnings: bool,
 ) -> list[StateRecord]:
     """Identify alert records from all states.

--- a/tests/test_state_analysis.py
+++ b/tests/test_state_analysis.py
@@ -3,14 +3,16 @@
 
 """Tests for the frequenz.reporting package."""
 
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
-from frequenz.client.common.microgrid.components import (
-    ComponentErrorCode,
-    ComponentStateCode,
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentDiagnosticCode,
+    ElectricalComponentStateCode,
 )
+from frequenz.client.common.proto import enum_from_proto
 from frequenz.client.reporting._types import MetricSample
 
 from frequenz.lib.notebooks.reporting.state_analysis import (
@@ -19,11 +21,19 @@ from frequenz.lib.notebooks.reporting.state_analysis import (
     _resolve_enum_name,
 )
 
+
+@dataclass(frozen=True)
+class _DiagnosticValue:
+    """Test helper to mimic reporting diagnostic payloads."""
+
+    diagnostic_code: int
+
+
 test_cases_extract_state_durations = [
     {
         "description": "Empty samples",
         "samples": [],
-        "alert_states": [ComponentStateCode.from_proto(1)],  # type: ignore[arg-type]
+        "alert_states": [enum_from_proto(1, ElectricalComponentStateCode)],
         "include_warnings": True,
         "expected_all_states": [],
         "expected_alert_records": [],
@@ -34,7 +44,7 @@ test_cases_extract_state_durations = [
             MetricSample(datetime(2023, 1, 1, 0, 0), 1, "101", "temperature", 25),
             MetricSample(datetime(2023, 1, 1, 1, 0), 1, "101", "humidity", 60),
         ],
-        "alert_states": [ComponentStateCode.from_proto(1)],  # type: ignore[arg-type]
+        "alert_states": [enum_from_proto(1, ElectricalComponentStateCode)],
         "include_warnings": True,
         "expected_all_states": [],
         "expected_alert_records": [],
@@ -45,14 +55,14 @@ test_cases_extract_state_durations = [
             MetricSample(datetime(2023, 1, 1, 0, 0), 1, "101", "state", 0),
             MetricSample(datetime(2023, 1, 1, 1, 0), 1, "101", "state", 1),
         ],
-        "alert_states": [ComponentStateCode.from_proto(1)],  # type: ignore[arg-type]
+        "alert_states": [enum_from_proto(1, ElectricalComponentStateCode)],
         "include_warnings": True,
         "expected_all_states": [
             {
                 "microgrid_id": 1,
                 "component_id": "101",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(0, ComponentStateCode),
+                "state_value": _resolve_enum_name(0, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 1, 0, 0),
                 "end_time": datetime(2023, 1, 1, 1, 0),
             },
@@ -60,7 +70,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 1,
                 "component_id": "101",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(1, ComponentStateCode),
+                "state_value": _resolve_enum_name(1, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 1, 1, 0),
                 "end_time": None,
             },
@@ -70,7 +80,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 1,
                 "component_id": "101",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(1, ComponentStateCode),
+                "state_value": _resolve_enum_name(1, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 1, 1, 0),
                 "end_time": None,
             },
@@ -81,19 +91,31 @@ test_cases_extract_state_durations = [
         "samples": [
             MetricSample(datetime(2023, 1, 2, 0, 0), 3, "303", "state", 0),
             MetricSample(datetime(2023, 1, 2, 0, 30), 3, "303", "state", 10),
-            MetricSample(datetime(2023, 1, 2, 0, 30), 3, "303", "warning", 10),
+            MetricSample(
+                datetime(2023, 1, 2, 0, 30),
+                3,
+                "303",
+                "warning",
+                cast(Any, _DiagnosticValue(10)),
+            ),
             MetricSample(datetime(2023, 1, 2, 1, 0), 3, "303", "state", 1),
             MetricSample(datetime(2023, 1, 2, 1, 30), 3, "303", "state", 20),
-            MetricSample(datetime(2023, 1, 2, 1, 30), 3, "303", "error", 20),
+            MetricSample(
+                datetime(2023, 1, 2, 1, 30),
+                3,
+                "303",
+                "error",
+                cast(Any, _DiagnosticValue(20)),
+            ),
         ],
-        "alert_states": [ComponentStateCode.from_proto(1)],  # type: ignore[arg-type]
+        "alert_states": [enum_from_proto(1, ElectricalComponentStateCode)],
         "include_warnings": True,
         "expected_all_states": [
             {
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(0, ComponentStateCode),
+                "state_value": _resolve_enum_name(0, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 2, 0, 0),
                 "end_time": datetime(2023, 1, 2, 0, 30),
             },
@@ -101,7 +123,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(10, ComponentStateCode),
+                "state_value": _resolve_enum_name(10, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 2, 0, 30),
                 "end_time": datetime(2023, 1, 2, 1, 0),
             },
@@ -109,7 +131,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(1, ComponentStateCode),
+                "state_value": _resolve_enum_name(1, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 2, 1, 0),
                 "end_time": datetime(2023, 1, 2, 1, 30),
             },
@@ -117,7 +139,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(20, ComponentStateCode),
+                "state_value": _resolve_enum_name(20, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 2, 1, 30),
                 "end_time": None,
             },
@@ -125,7 +147,9 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "warning",
-                "state_value": _resolve_enum_name(10, ComponentErrorCode),
+                "state_value": _resolve_enum_name(
+                    10, ElectricalComponentDiagnosticCode
+                ),
                 "start_time": datetime(2023, 1, 2, 0, 30),
                 "end_time": datetime(2023, 1, 2, 1, 0),
             },
@@ -135,7 +159,9 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "warning",
-                "state_value": _resolve_enum_name(10, ComponentErrorCode),
+                "state_value": _resolve_enum_name(
+                    10, ElectricalComponentDiagnosticCode
+                ),
                 "start_time": datetime(2023, 1, 2, 0, 30),
                 "end_time": datetime(2023, 1, 2, 1, 0),
             },
@@ -143,7 +169,7 @@ test_cases_extract_state_durations = [
                 "microgrid_id": 3,
                 "component_id": "303",
                 "state_type": "state",
-                "state_value": _resolve_enum_name(1, ComponentStateCode),
+                "state_value": _resolve_enum_name(1, ElectricalComponentStateCode),
                 "start_time": datetime(2023, 1, 2, 1, 0),
                 "end_time": datetime(2023, 1, 2, 1, 30),
             },
@@ -215,19 +241,25 @@ def test_extract_and_filter_state_records(test_case: dict[str, Any]) -> None:
 @pytest.mark.parametrize(
     "value, enum_class, expected_name",
     [
-        (ComponentStateCode.READY.value, ComponentStateCode, "READY"),
-        (ComponentStateCode.OFF.value, ComponentStateCode, "OFF"),
         (
-            ComponentErrorCode.OVERTEMPERATURE.value,
-            ComponentErrorCode,
+            ElectricalComponentStateCode.READY.value,
+            ElectricalComponentStateCode,
+            "READY",
+        ),
+        (ElectricalComponentStateCode.OFF.value, ElectricalComponentStateCode, "OFF"),
+        (
+            ElectricalComponentDiagnosticCode.OVERTEMPERATURE.value,
+            ElectricalComponentDiagnosticCode,
             "OVERTEMPERATURE",
         ),
-        (ComponentErrorCode.SHORT_CIRCUIT.value, ComponentErrorCode, "SHORT_CIRCUIT"),
-        (9999.0, ComponentStateCode, "UNSPECIFIED"),  # Invalid state code
-        (-8888.0, ComponentErrorCode, "UNSPECIFIED"),  # Invalid error code
+        (
+            ElectricalComponentDiagnosticCode.SHORT_CIRCUIT.value,
+            ElectricalComponentDiagnosticCode,
+            "SHORT_CIRCUIT",
+        ),
     ],
 )
 def test_resolve_enum_name(value: int, enum_class: Any, expected_name: str) -> None:
-    """Test resolving enum names from float values."""
-    result = _resolve_enum_name(float(value), enum_class)
+    """Test resolving enum names from integer values."""
+    result = _resolve_enum_name(value, enum_class)
     assert result == expected_name


### PR DESCRIPTION
Fix the alerts notebook that was broken due to:
- reliance on old enum types
- incorrect handling of new type of error/warning diagnostic values returned by the reporting api

Changes:
- Switch to `ElectricalComponentStateCode` and
  `ElectricalComponentDiagnosticCode`
- Replace deprecated `from_proto()` with `enum_from_proto()`
- Access diagnostic enums via `diagnostic_code`
- Extend typing around `MetricSample.value`
- Update tests and docstrings