### PR TITLE
Normalize report date handling and update color map docs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,8 @@
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
+- `build_color_map` now sources default colors from the in-code color dictionary rather than a YAML file.
 
 ## Bug Fixes
 
-Fix state analysis to support new `ElectricalComponent*Code` enums and diagnostic code handling.
+- Added `normalize_date_for_report` to return current time for today, midnight for past dates, and reject future dates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   "types-pyyaml>=6.0.12.20250915",
   "marshmallow>=4.1.0,<5",
   "pyyaml>=6.0.3",
-  "pytz>=2025.2",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/lib/notebooks/reporting/plotter.py
+++ b/src/frequenz/lib/notebooks/reporting/plotter.py
@@ -165,7 +165,7 @@ def plot_time_series(
                 bgcolor="rgba(0,0,0,0)",  # Transparent background
                 activecolor="#2C7BE5",  # Highlight color for active button
                 font=dict(size=12),
-                x=0.65,
+                x=0,
                 xanchor="left",
                 y=1.05,
                 yanchor="top",

--- a/src/frequenz/lib/notebooks/reporting/plotter.py
+++ b/src/frequenz/lib/notebooks/reporting/plotter.py
@@ -6,8 +6,23 @@
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
+from matplotlib import colors as mcolors
 
 from frequenz.lib.notebooks.reporting.utils.helpers import build_color_map, long_to_wide
+
+
+def _with_alpha(color: str | None, alpha: float) -> str | None:
+    """Return color as rgba string with the given alpha, or None if invalid."""
+    if not color:
+        return None
+    try:
+        r, g, b, _ = mcolors.to_rgba(color)
+    except ValueError:
+        return None
+    r255 = int(round(r * 255))
+    g255 = int(round(g * 255))
+    b255 = int(round(b * 255))
+    return f"rgba({r255},{g255},{b255},{alpha:.3f})"
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments,
@@ -98,11 +113,9 @@ def plot_time_series(
 
     # Add one line trace per column
     for i, col in enumerate(cols):
-        fill_mode = "tonextx" if col in fill_cols else "none"
+        fill_mode = "tozeroy" if col in fill_cols else "none"
         line_color = color_map.get(col)
-        fill_color = (
-            line_color.replace("1)", "0.3)") if isinstance(line_color, str) else None
-        )
+        fill_color = _with_alpha(line_color, 0.9)
 
         fig.add_trace(
             go.Scatter(

--- a/src/frequenz/lib/notebooks/reporting/plotter.py
+++ b/src/frequenz/lib/notebooks/reporting/plotter.py
@@ -40,6 +40,7 @@ def plot_time_series(
     category_col: str | None = None,
     value_col: str | None = None,
     fill_cols: list[str] | None = None,
+    dotted_cols: list[str] | None = None,
     plot_order: list[str] | None = None,
 ) -> go.Figure:
     """Create an interactive time-series plot using Plotly.
@@ -68,6 +69,8 @@ def plot_time_series(
             format. Used only if `long_format_flag=True`.
         fill_cols: List of column names to plot as filled areas under the curve.
             Defaults to None (no fill).
+        dotted_cols: List of column names to render with dotted lines.
+            Defaults to None (no dotted lines).
         plot_order: Optional list specifying the order of columns to plot. If None,
             the order in `cols` is used.
 
@@ -110,6 +113,9 @@ def plot_time_series(
     # Check if fill_cols is provided
     if fill_cols is None:
         fill_cols = []
+    if dotted_cols is None:
+        dotted_cols = []
+    dotted_set = set(dotted_cols)
 
     # Add one line trace per column
     for i, col in enumerate(cols):
@@ -123,7 +129,11 @@ def plot_time_series(
                 y=pdf[col],
                 mode="lines",
                 name=col,
-                line=dict(color=line_color, shape="hv"),
+                line=dict(
+                    color=line_color,
+                    shape="hv",
+                    dash="dot" if col in dotted_set else "solid",
+                ),
                 fill=fill_mode,
                 fillcolor=fill_color,
                 legendrank=rank_map.get(col, 10_000 + i),

--- a/src/frequenz/lib/notebooks/reporting/plotter.py
+++ b/src/frequenz/lib/notebooks/reporting/plotter.py
@@ -129,6 +129,7 @@ def plot_time_series(
                 y=pdf[col],
                 mode="lines",
                 name=col,
+                hovertemplate=f"<b>{col}</b>: %{{y}} {yaxis_title}<extra></extra>",
                 line=dict(
                     color=line_color,
                     shape="hv",
@@ -181,6 +182,7 @@ def plot_time_series(
         legend=dict(title=dict(text=legend_title), traceorder="normal"),
         xaxis_title=xaxis_title,
         yaxis_title=yaxis_title,
+        hovermode="x unified",
         template="plotly_white",
     )
     return fig

--- a/src/frequenz/lib/notebooks/reporting/utils/colors.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/colors.py
@@ -1,0 +1,23 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Default color mapping for reporting plots."""
+
+from __future__ import annotations
+
+COLOR_DICT: dict[str, str] = {
+    "PV": "rgba(255,243,138,1)",
+    "PV-Erzeugung": "rgba(255,243,138,1)",
+    "PV-Erzeugung [kWh]": "rgba(255,243,138,1)",
+    "PV-Erzeugung [kWh] Sum": "rgba(255,243,138,1)",
+    "Wind": "rgba(100,149,237,1)",
+    "Wind-Erzeugung": "rgba(100,149,237,1)",
+    "Wind-Erzeugung [kWh] Sum": "rgba(100,149,237,1)",
+    "BHKW": "rgba(255,140,0,1)",
+    "BHKW-Erzeugung": "rgba(255,140,0,1)",
+    "BHKW-Erzeugung [kWh] Sum": "rgba(255,140,0,1)",
+    "Netto Gesamtverbrauch": "rgba(70,70,70,1)",
+    "MID Gesamtverbrauch": "rgba(70,70,70,1)",
+    "Batterie Leistungsfluss": "rgba(0,204,150,1)",
+    "Netzbezug": "rgba(0,0,0,1)",
+}

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -39,11 +39,11 @@ from __future__ import annotations
 import warnings
 from datetime import date, datetime, time
 from typing import Any, Literal, Mapping, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import matplotlib.colors as mcolors
 import pandas as pd
 import plotly.express as px
-import pytz
 import yaml
 from frequenz.gridpool import MicrogridConfig
 
@@ -517,13 +517,13 @@ def set_date_to_midnight(
         input_date = input_date.date()
 
     try:
-        tz = pytz.timezone(timezone_name)
-    except pytz.UnknownTimeZoneError:
+        tz = ZoneInfo(timezone_name)
+    except (ZoneInfoNotFoundError, KeyError):
         warnings.warn(
             f"Unknown timezone '{timezone_name}', falling back to UTC.",
             RuntimeWarning,
         )
-        tz = pytz.UTC
+        tz = ZoneInfo("UTC")
 
     return tz.localize(datetime.combine(input_date, time.min))
 

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -57,6 +57,7 @@ from frequenz.lib.notebooks.reporting.metrics.reporting_metrics import (
     production_self_consumption,
     production_self_share,
 )
+from frequenz.lib.notebooks.reporting.utils.colors import COLOR_DICT
 
 AggregatedComponentConfig = Mapping[str, tuple[str, str]]
 
@@ -642,13 +643,13 @@ def build_color_map(
     """Generate a color mapping for columns or categories.
 
     Creates a mapping from column names (or categorical labels) to color
-    values. If user-specified colors are provided via `color_dict`, those
-    are applied first. Remaining columns are assigned distinct colors from
-    a chosen palette, ensuring no duplicates.
+    values. Default colors are sourced from the in-code color dictionary
+    and can be overridden via `color_dict`. Remaining columns are assigned
+    distinct colors from a chosen palette, ensuring no duplicates.
 
     Args:
         cols: List of column names or category labels to assign colors to.
-        color_dict: Optional dictionary of pre-defined color mappings.
+        color_dict: Optional dictionary of color mappings to override defaults.
             Columns found here are assigned these colors directly.
         palette: Optional list of color codes to use as defaults.
             If None, a combined Plotly qualitative palette is used.
@@ -673,13 +674,16 @@ def build_color_map(
     final = {}
     used = set()
 
-    # First assign user-provided colors
+    # First assign default colors, then override with user-provided
+    merged_color_dict = COLOR_DICT
     if color_dict:
-        for c, v in color_dict.items():
-            if c in cols:
-                rgba = to_rgba_str(v)
-                final[c] = rgba
-                used.add(rgba)
+        merged_color_dict = {**merged_color_dict, **color_dict}
+
+    for c, v in merged_color_dict.items():
+        if c in cols:
+            rgba = to_rgba_str(v)
+            final[c] = rgba
+            used.add(rgba)
 
     # Then assign defaults, skipping already-used colors
     palette_iter = iter(palette * (len(cols) // len(palette) + 1))

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -525,7 +525,52 @@ def set_date_to_midnight(
         )
         tz = ZoneInfo("UTC")
 
-    return tz.localize(datetime.combine(input_date, time.min))
+    return datetime.combine(input_date, time.min).replace(tzinfo=tz)
+
+
+def normalize_date_for_reporting(
+    input_date: date | datetime, timezone_name: str = "UTC"
+) -> datetime:
+    """Return midnight for past dates or current time for today.
+
+    If the input date is today (in the target timezone), this returns the
+    current time in that timezone. If the date is in the future, a ValueError
+    is raised to prevent selecting future dates. For past dates, midnight is
+    returned via ``set_date_to_midnight``.
+
+    Args:
+        input_date: Date or datetime object to evaluate.
+        timezone_name: Name of the target timezone (e.g., "Europe/Berlin").
+            Defaults to "UTC". Falls back to UTC if the timezone name
+            is invalid.
+
+    Returns:
+        A timezone-aware datetime object representing the current time
+        when the input date is today, or midnight for past dates.
+
+    Raises:
+        ValueError: If the input date is in the future.
+    """
+    input_day = input_date.date() if isinstance(input_date, datetime) else input_date
+
+    try:
+        tz = ZoneInfo(timezone_name)
+    except (ZoneInfoNotFoundError, KeyError):
+        warnings.warn(
+            f"Unknown timezone '{timezone_name}', falling back to UTC.",
+            RuntimeWarning,
+        )
+        tz = ZoneInfo("UTC")
+
+    now = datetime.now(tz)
+    today = now.date()
+
+    if input_day > today:
+        raise ValueError("Future dates can't be selected.")
+    if input_day == today:
+        return now
+
+    return set_date_to_midnight(input_date, timezone_name)
 
 
 AggFuncLiteral = Literal[

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime
 from typing import cast
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import pytest
-import pytz
 from frequenz.gridpool import MicrogridConfig
 from pandas.testing import assert_frame_equal, assert_series_equal
 
@@ -153,20 +153,19 @@ def test_label_component_columns_applies_expected_prefixes() -> None:
 def test_set_date_to_midnight_creates_timezone_aware_midnight() -> None:
     """Date and datetime inputs both produce midnight timestamps in the target TZ."""
     result_date = set_date_to_midnight(date(2024, 5, 1), "Europe/Berlin")
-    expected_date = pytz.timezone("Europe/Berlin").localize(datetime(2024, 5, 1))
+    expected_date = datetime(2024, 5, 1, tzinfo=ZoneInfo("Europe/Berlin"))
     assert result_date == expected_date
 
     noon_input = datetime(2024, 5, 2, 12, 30)
     result_datetime = set_date_to_midnight(noon_input, "UTC")
-    tz_utc = pytz.timezone("UTC")
-    assert result_datetime == tz_utc.localize(datetime(2024, 5, 2))
+    assert result_datetime == datetime(2024, 5, 2, tzinfo=ZoneInfo("UTC"))
 
 
 def test_set_date_to_midnight_unknown_timezone_warns_and_falls_back() -> None:
     """Unknown timezone name triggers a warning and falls back to UTC."""
     with pytest.warns(RuntimeWarning):
         result = set_date_to_midnight(date(2024, 6, 1), "Invalid/Zone")
-    assert result == pytz.timezone("UTC").localize(datetime(2024, 6, 1))
+    assert result == datetime(2024, 6, 1, tzinfo=ZoneInfo("UTC"))
 
 
 def test_long_to_wide_pivots_and_adds_sum_column() -> None:


### PR DESCRIPTION
Updates reporting utilities to improve date/time handling and plotting defaults with centralized color configuration.

Changes:

- Replaced pytz usage with zoneinfo and added `normalize_date_for_report()` to return current time for today, midnight for past dates, and reject future dates.
- Update `build_color_map()` with default color_dict.
- Extended `plot_time_series()` with dotted_cols and tweaked fill behavior / layout positioning.