### PR TITLE
Remove prod positive argument

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,9 @@
 
 ## Upgrading
 
+- Reporting metrics now consistently assume PSC sign conventions for production and no longer accept a `production_is_positive` toggle.
+- Removed `production_is_positive` from reporting metric helpers and `add_energy_flows()`.
+- If you previously passed already-positive production to these helpers, pass `-production` instead (PSC convention: production is negative).
 
 ## New Features
 

--- a/src/frequenz/lib/notebooks/reporting/data_processing.py
+++ b/src/frequenz/lib/notebooks/reporting/data_processing.py
@@ -89,7 +89,6 @@ def create_energy_report_df(
         consumption_cols=["consumption"],
         grid_cols=["grid"],
         battery_cols=["battery"],
-        production_is_positive=False,
     )
 
     # Standardize column names (from raw to canonical)

--- a/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
+++ b/src/frequenz/lib/notebooks/reporting/metrics/reporting_metrics.py
@@ -8,7 +8,7 @@ flows within a hybrid power system — including production, consumption,
 battery charging, grid feed-in, and self-consumption metrics.
 
 Key features:
-It standardizes sign conventions (via `production_is_positive`) and ensures
+It standardizes sign conventions (production is negative in PSC) and ensures
 consistency in derived quantities such as:
   - Production surplus (excess generation)
   - Energy stored in a battery
@@ -26,46 +26,36 @@ import warnings
 import pandas as pd
 
 
-def asset_production(
-    production: pd.Series, production_is_positive: bool = False
-) -> pd.Series:
+def asset_production(production: pd.Series) -> pd.Series:
     """Extract the positive production portion from a power series.
 
-    Ensures only productive (non-negative) values remain, regardless of the
-    sign convention used for production vs. consumption.
+    Assumes PSC convention (production negative) and inverts to keep the
+    productive (non-negative) portion.
 
     Args:
         production: Series of power values (e.g., kW or MW).
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A Series where only production values (≥ 0) are retained, with all
         non-productive values set to zero. Missing values remain NaN.
     """
-    return (production if production_is_positive else -production).clip(lower=0)
+    return (-production).clip(lower=0)
 
 
-def production_excess(
-    production: pd.Series, consumption: pd.Series, production_is_positive: bool = False
-) -> pd.Series:
+def production_excess(production: pd.Series, consumption: pd.Series) -> pd.Series:
     """Compute the excess production relative to consumption.
 
     Calculates surplus by subtracting consumption from production and removing
     negative results. Production is optionally sign-corrected first.
 
     Args:
-        production: Series of production values (e.g., kW or MW).
+        production: Series of production values (PSC convention, negative).
         consumption: Series of consumption values (same units as `production`).
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A Series representing excess production (≥ 0).
     """
-    asset_production_series = asset_production(
-        production, production_is_positive=production_is_positive
-    )
+    asset_production_series = asset_production(production)
     return (asset_production_series - consumption).clip(lower=0)
 
 
@@ -73,7 +63,6 @@ def production_excess_in_bat(
     production: pd.Series,
     consumption: pd.Series,
     battery: pd.Series,
-    production_is_positive: bool = False,
 ) -> pd.Series:
     """Calculate the portion of excess production stored in the battery.
 
@@ -85,15 +74,11 @@ def production_excess_in_bat(
         consumption: Series of consumption values (same units as `production`).
         battery: Series representing the battery's available charging capacity
             or power limit at each timestamp.
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A Series showing the actual production power stored in the battery.
     """
-    production_excess_series = production_excess(
-        production, consumption, production_is_positive=production_is_positive
-    )
+    production_excess_series = production_excess(production, consumption)
     battery = battery.astype("float64").clip(lower=0)
     return pd.concat([production_excess_series, battery], axis=1).min(axis=1)
 
@@ -144,7 +129,7 @@ def grid_feed_in(
 
 
 def production_self_consumption(
-    production: pd.Series, consumption: pd.Series, production_is_positive: bool = False
+    production: pd.Series, consumption: pd.Series
 ) -> pd.Series:
     """Compute the portion of production directly self-consumed.
 
@@ -154,8 +139,6 @@ def production_self_consumption(
     Args:
         production: Series of production values (e.g., kW or MW).
         consumption: Series of consumption values (same units as `production`).
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A Series representing self-consumed production.
@@ -164,12 +147,8 @@ def production_self_consumption(
         UserWarning: If negative self-consumption values are detected, indicating
             that the computed excess exceeds total production for some entries.
     """
-    asset_production_series = asset_production(
-        production, production_is_positive=production_is_positive
-    )
-    production_excess_series = production_excess(
-        production, consumption, production_is_positive=production_is_positive
-    )
+    asset_production_series = asset_production(production)
+    production_excess_series = production_excess(production, consumption)
     result = asset_production_series - production_excess_series
 
     if (result < 0).any():
@@ -183,9 +162,7 @@ def production_self_consumption(
     return result
 
 
-def production_self_usage(
-    production: pd.Series, consumption: pd.Series, production_is_positive: bool = False
-) -> pd.Series:
+def production_self_usage(production: pd.Series, consumption: pd.Series) -> pd.Series:
     """Calculate the self-consumption share of total consumption.
 
     Computes the ratio of self-used production to total consumption,
@@ -194,52 +171,36 @@ def production_self_usage(
     Args:
         production: Series of production values (e.g., kW or MW).
         consumption: Series of consumption values (same units as `production`).
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A Series expressing the self-consumption share (values between 0 and 1).
         Returns NaN where consumption is zero.
     """
-    production_self_use = production_self_consumption(
-        production, consumption, production_is_positive=production_is_positive
-    )
+    production_self_use = production_self_consumption(production, consumption)
     denom = consumption.astype("float64")
     denom = denom.mask(denom <= 0)  # NaN when consumption <= 0
     share = production_self_use.astype("float64") / denom
     return share
 
 
-def production_self_share(
-    production: pd.Series, consumption: pd.Series, production_is_positive: bool = False
-) -> pd.Series:
+def production_self_share(production: pd.Series, consumption: pd.Series) -> pd.Series:
     """Compute the self-consumption share relative to total production.
 
     Calculates the fraction of total production that is directly self-consumed.
-    The denominator is the positive production portion (after applying the
-    sign convention), and values are masked to ``NaN`` where production is
-    zero or negative to avoid invalid divisions.
+    The denominator is the positive production portion, and values are masked
+    to ``NaN`` where production is zero or negative to avoid invalid divisions.
 
     Args:
         production:
             Series of production power values (e.g., kW).
         consumption:
             Series of consumption power values (same unit as ``production``).
-        production_is_positive:
-            Whether production values are already positive. If ``False``,
-            the production series is inverted before clipping to its
-            positive (productive) portion.
-
     Returns:
         Series of self-consumption share values (typically between 0 and 1).
         Returns ``NaN`` for timestamps where total production is zero or negative.
     """
-    production_self_use = production_self_consumption(
-        production, consumption, production_is_positive=production_is_positive
-    )
-    denom = asset_production(
-        production, production_is_positive=production_is_positive
-    ).astype("float64")
+    production_self_use = production_self_consumption(production, consumption)
+    denom = asset_production(production).astype("float64")
     denom = denom.mask(denom <= 0)  # NaN when production <= 0
     return production_self_use.astype("float64") / denom
 

--- a/src/frequenz/lib/notebooks/reporting/utils/helpers.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/helpers.py
@@ -351,7 +351,6 @@ def add_energy_flows(
     consumption_cols: list[str] | None = None,
     grid_cols: list[str] | None = None,
     battery_cols: list[str] | None = None,
-    production_is_positive: bool = False,
 ) -> pd.DataFrame:
     """Compute and add derived energy flow metrics to the DataFrame.
 
@@ -368,8 +367,6 @@ def add_energy_flows(
         grid_cols: list of column names representing grid import/export.
         battery_cols: optional list of column names for battery charging power. If None,
             battery-related flows are set to zero.
-        production_is_positive: Whether production values are already positive.
-            If False, `production` is inverted before clipping.
 
     Returns:
         A DataFrame including additional columns:
@@ -413,7 +410,6 @@ def add_energy_flows(
         )
         asset_series = asset_production(
             series,
-            production_is_positive=production_is_positive,
         )
         asset_col_name = f"{col}_asset_production"
         df_flows[asset_col_name] = asset_series
@@ -444,17 +440,15 @@ def add_energy_flows(
 
     # Surplus vs. consumption (production is already positive because of the above cleaning)
     df_flows["production_excess"] = production_excess(
-        df_flows["production_total"],
+        df_flows["production_total"] * -1,
         df_flows["consumption_total"],
-        production_is_positive=True,
     )
 
     # Battery charging power (optional)
     df_flows["production_excess_in_bat"] = production_excess_in_bat(
-        df_flows["production_total"],
+        df_flows["production_total"] * -1,
         df_flows["consumption_total"],
         battery=battery_charge_series,
-        production_is_positive=True,
     )
 
     # Split excess into battery vs. grid
@@ -471,19 +465,16 @@ def add_energy_flows(
         # Use total production for self-consumption instead of asset_production
         # (which may not exist)
         df_flows["production_self_use"] = production_self_consumption(
-            df_flows["production_total"],
+            df_flows["production_total"] * -1,
             df_flows["consumption_total"],
-            production_is_positive=True,
         )
         df_flows["production_self_share"] = production_self_share(
-            df_flows["production_total"],
+            df_flows["production_total"] * -1,
             df_flows["consumption_total"],
-            production_is_positive=True,
         )
         df_flows["production_self_usage"] = production_self_usage(
-            df_flows["production_total"],
+            df_flows["production_total"] * -1,
             df_flows["consumption_total"],
-            production_is_positive=True,
         )
     else:
         df_flows["production_self_use"] = 0.0

--- a/tests/test_reporting_metrics.py
+++ b/tests/test_reporting_metrics.py
@@ -13,16 +13,12 @@ from frequenz.lib.notebooks.reporting.metrics import reporting_metrics as metric
 
 
 def test_asset_production_respects_sign_and_missing_values() -> None:
-    """Positive flag controls sign inversion and NaNs stay missing."""
-    production = pd.Series([10, -5, None], index=pd.RangeIndex(3))
+    """Production is negated and NaNs stay missing."""
+    production = pd.Series([-10, 5, None], index=pd.RangeIndex(3))
 
-    positive = metrics.asset_production(production, production_is_positive=True)
-    expected_positive = pd.Series([10.0, 0.0, float("nan")], index=production.index)
-    assert_series_equal(positive, expected_positive)
-
-    negative = metrics.asset_production(production, production_is_positive=False)
-    expected_negative = pd.Series([0.0, 5.0, float("nan")], index=production.index)
-    assert_series_equal(negative, expected_negative)
+    result = metrics.asset_production(production)
+    expected = pd.Series([10.0, 0.0, float("nan")], index=production.index)
+    assert_series_equal(result, expected)
 
 
 def test_production_excess_clips_negative_surplus() -> None:


### PR DESCRIPTION
Remove the production_is_positive toggle and standardize reporting metrics to always use PSC sign conventions (production is negative). Update all call sites and tests to pass -production where needed, and document the change in release notes.

- Removed production_is_positive from reporting metrics helpers and add_energy_flows().
- Standardized production sign handling by negating production inside metrics helpers.
- Updated callers to pass -production where required.
- Updated tests and release notes.