### PR TITLE
Add Battery Usecase plot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,8 @@ reporting data workflows. When API credentials are available, microgrid
 configurations are enriched with formulas from the Assets service; otherwise
 the existing static config loading path is used.
 
-Also fixed asset optimization battery and power-flow rendering for more accurate charge/discharge visuals.
+It also adds a dedicated reporting battery-usecase plot, including standardized
+data preparation and support for PV and battery overlays.
 
 ## Upgrading
 
@@ -18,6 +19,10 @@ Also fixed asset optimization battery and power-flow rendering for more accurate
 ## New Features
 
 - Refactored asset optimization Plotly code to reduce duplication in layout finalization and battery trace creation.
+- `plot_time_series_battery_usecase()`
+  - added as a dedicated reporting plot for battery-usecase analysis.
+- `create_battery_usecase_df()`
+  - added to prepare standardized input data for the battery-usecase plot.
 
 ## Bug Fixes
 - Fixed asset optimization power-flow charge/discharge fills to be anchored to the consumption baseline while keeping hover values on actual series.

--- a/src/frequenz/lib/notebooks/reporting/__init__.py
+++ b/src/frequenz/lib/notebooks/reporting/__init__.py
@@ -2,3 +2,7 @@
 # Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
 """Initialise the reporting related modules."""
+
+from .data_processing import create_battery_usecase_df, create_energy_report_df
+
+__all__ = ["create_energy_report_df", "create_battery_usecase_df"]

--- a/src/frequenz/lib/notebooks/reporting/data_processing.py
+++ b/src/frequenz/lib/notebooks/reporting/data_processing.py
@@ -11,9 +11,11 @@ metrics used downstream for dashboards.
 Functions:
 ------------
 - Energy Report DataFrame Construction
-  - :func:`create_energy_report_df`: Builds a normalized energy report table with
+  - `create_energy_report_df`: Builds a normalized energy report table with
     unified naming, timezone conversion, grid import calculation, and
     component renaming based on a MicrogridConfig.
+  - `create_battery_usecase_df`: Builds the standardized battery-usecase table
+    used by the reporting plot helpers.
 
 Usage:
 -----
@@ -34,6 +36,80 @@ from frequenz.lib.notebooks.reporting.utils.helpers import (
     get_energy_report_columns,
     label_component_columns,
 )
+
+
+def create_battery_usecase_df(
+    energy_report_df: pd.DataFrame,
+    *,
+    timestamp_col: str = "timestamp",
+    grid_consumption_col: str = "grid_consumption",
+    battery_col: str = "battery_power_flow",
+    pv_col: str | None = "pv_asset_production",
+) -> pd.DataFrame:
+    """Create a standardized battery-usecase DataFrame.
+
+    Selects the battery-usecase input columns from the source DataFrame, renames
+    them to the standardized reporting schema, derives grid consumption without
+    battery support, computes reference peak lines, and splits battery power
+    flow into charging and discharging series.
+
+    Args:
+        energy_report_df: Reporting DataFrame containing the source columns for
+            timestamp, grid consumption, and battery power flow.
+        timestamp_col: Column name in `energy_report_df` containing the
+            timestamps.
+        grid_consumption_col: Column name in `energy_report_df` containing
+            grid consumption with battery support.
+        battery_col: Column name in `energy_report_df` containing
+            battery power flow.
+        pv_col: Optional column name in `energy_report_df` containing
+            PV production to preserve in the standardized output when present.
+
+    Returns:
+        The battery-usecase DataFrame with derived helper columns for plotting
+        and analysis.
+
+    Raises:
+        KeyError: If required columns are missing from the input DataFrame.
+    """
+    required_cols = [timestamp_col, grid_consumption_col, battery_col]
+    missing_cols = [col for col in required_cols if col not in energy_report_df.columns]
+    if missing_cols:
+        raise KeyError(
+            "Missing required columns in energy_report_df: "
+            + ", ".join(sorted(missing_cols))
+        )
+
+    selected_cols = list(required_cols)
+    rename_map = {
+        timestamp_col: "timestamp",
+        grid_consumption_col: "grid_consumption",
+        battery_col: "battery_power_flow",
+    }
+    if pv_col and pv_col in energy_report_df.columns:
+        selected_cols.append(pv_col)
+        rename_map[pv_col] = "pv"
+
+    battery_usecase_df = energy_report_df[selected_cols].rename(columns=rename_map)
+    battery_usecase_df["grid_consumption_without_battery"] = (
+        battery_usecase_df["grid_consumption"]
+        + battery_usecase_df["battery_power_flow"]
+    )
+
+    battery_usecase_df["peak_before_optimization"] = battery_usecase_df[
+        "grid_consumption_without_battery"
+    ].max()
+    battery_usecase_df["peak_after_optimization"] = battery_usecase_df[
+        "grid_consumption"
+    ].max()
+    battery_usecase_df["battery_discharge"] = battery_usecase_df[
+        "battery_power_flow"
+    ].clip(lower=0)
+    battery_usecase_df["battery_charge"] = battery_usecase_df[
+        "battery_power_flow"
+    ].clip(upper=0)
+
+    return battery_usecase_df
 
 
 # pylint: disable=too-many-arguments, too-many-locals

--- a/src/frequenz/lib/notebooks/reporting/plotter.py
+++ b/src/frequenz/lib/notebooks/reporting/plotter.py
@@ -3,11 +3,17 @@
 
 """Plotting functions for the reporting module."""
 
+from collections.abc import Sequence
+
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from matplotlib import colors as mcolors
 
+from frequenz.lib.notebooks.reporting.utils.battery_usecase_plot import (
+    _with_alpha,
+    add_battery_usecase_overlay_traces,
+    prepare_battery_usecase_plot,
+)
 from frequenz.lib.notebooks.reporting.utils.colors import (
     COLOR_DICT,
     LINE_DASH_MAP,
@@ -16,18 +22,12 @@ from frequenz.lib.notebooks.reporting.utils.colors import (
 from frequenz.lib.notebooks.reporting.utils.helpers import build_color_map, long_to_wide
 
 
-def _with_alpha(color: str | None, alpha: float) -> str | None:
-    """Return color as rgba string with the given alpha, or None if invalid."""
-    if not color:
-        return None
-    try:
-        r, g, b, _ = mcolors.to_rgba(color)
-    except ValueError:
-        return None
-    r255 = int(round(r * 255))
-    g255 = int(round(g * 255))
-    b255 = int(round(b * 255))
-    return f"rgba({r255},{g255},{b255},{alpha:.3f})"
+def _coerce_numeric_series(series: pd.Series) -> pd.Series:
+    """Convert series to numeric, handling comma decimal strings."""
+    if pd.api.types.is_numeric_dtype(series):
+        return pd.to_numeric(series, errors="coerce")
+    as_str = series.astype(str).str.replace(",", ".", regex=False)
+    return pd.to_numeric(as_str, errors="coerce")
 
 
 def _split_battery_power_flow(
@@ -116,6 +116,7 @@ def _apply_stack_for_production(
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments,
 # pylint: disable=use-dict-literal, too-many-locals, too-many-branches
+# pylint: disable=too-many-statements
 def plot_time_series(
     df: pd.DataFrame,
     time_col: str | None = None,
@@ -123,7 +124,7 @@ def plot_time_series(
     title: str = "Time Series Plot",
     xaxis_title: str = "Timestamp",
     yaxis_title: str = "kW",
-    legend_title: str | None = "Components",
+    legend_title: str | None = "",
     color_dict: dict[str, str] | None = None,
     long_format_flag: bool = False,
     category_col: str | None = None,
@@ -132,6 +133,8 @@ def plot_time_series(
     dotted_cols: list[str] | None = None,
     plot_order: list[str] | None = None,
     shade_by_category: bool = False,
+    secondary_y_cols: Sequence[str] | None = None,
+    secondary_y_title: str | None = None,
 ) -> go.Figure:
     """Create an interactive time-series plot using Plotly.
 
@@ -165,6 +168,9 @@ def plot_time_series(
             the order in `cols` is used.
         shade_by_category: When plotting a long-format series, render all
             categories as different shades of the same base color.
+        secondary_y_cols: Optional plotted columns to render on a secondary y-axis.
+        secondary_y_title: Optional title for the secondary y-axis. Defaults to
+            `secondary_y_cols` when not provided.
 
     Returns:
         A Plotly Figure object representing the interactive time-series plot.
@@ -194,8 +200,25 @@ def plot_time_series(
         pdf, cols, plot_order, fill_cols, dotted_cols
     )
 
+    if secondary_y_cols:
+        for col in secondary_y_cols:
+            if col not in cols and col in pdf.columns:
+                cols.append(col)
+
     # Safe reorder: use plot_order if provided, else keep cols as-is
     cols = [c for c in (plot_order or cols) if c in pdf.columns]
+
+    secondary_cols: list[str] = list(secondary_y_cols or [])
+
+    if secondary_cols:
+        for col in secondary_cols:
+            if col not in pdf.columns:
+                raise KeyError(f"Column '{col}' not found in DataFrame.")
+            if col not in cols:
+                raise KeyError(
+                    f"Secondary y-axis column '{col}' is not included in the plotted columns."
+                )
+    secondary_col_set = set(secondary_cols)
 
     pdf, stackgroup_map = _apply_stack_for_production(pdf, cols)
 
@@ -222,7 +245,6 @@ def plot_time_series(
     if dotted_cols is None:
         dotted_cols = []
     dotted_set = set(dotted_cols)
-
     # Add one line trace per column
     for i, col in enumerate(cols):
         stackgroup = stackgroup_map.get(col)
@@ -231,15 +253,26 @@ def plot_time_series(
         else:
             fill_mode = "tozeroy" if col in fill_cols else "none"
         line_color = color_map.get(col)
+        if col.lower() == "da_price":
+            line_color = COLOR_DICT.get("da_price", line_color)
         fill_color = _with_alpha(line_color, 0.9)
+        y_values = _coerce_numeric_series(pdf[col])
+        if col in secondary_col_set:
+            if col.lower() == "da_price":
+                trace_unit = "EUR/MWh"
+            else:
+                trace_unit = secondary_y_title or col
+        else:
+            trace_unit = yaxis_title
 
         fig.add_trace(
             go.Scatter(
                 x=pdf.index,
-                y=pdf[col],
+                y=y_values,
                 mode="lines",
                 name=col,
-                hovertemplate=f"<b>{col}</b>: %{{y}} {yaxis_title}<extra></extra>",
+                hovertemplate=f"<b>{col}</b>: %{{y}} {trace_unit}<extra></extra>",
+                yaxis="y2" if col in secondary_col_set else "y",
                 line=dict(
                     color=line_color,
                     shape="hv",
@@ -260,11 +293,14 @@ def plot_time_series(
     fig.update_layout(
         title=dict(
             text=title,
-            x=0.1,  # Center
+            x=0.08,  # Center
+            y=0.99,
             xanchor="left",
             yanchor="top",
             font=dict(size=22),
         ),
+        height=700,
+        width=950,
         margin=dict(t=120),
         xaxis=dict(
             type="date",
@@ -282,7 +318,7 @@ def plot_time_series(
                 font=dict(size=12),
                 x=0,
                 xanchor="left",
-                y=1.05,
+                y=1.1,
                 yanchor="top",
             ),
             rangeslider=dict(  # Add an interactive range slider below the x-axis
@@ -293,11 +329,144 @@ def plot_time_series(
                 thickness=0.09,
             ),
         ),
-        legend=dict(title=dict(text=legend_title), traceorder="normal"),
+        legend=dict(
+            title=dict(text=legend_title),
+            traceorder="normal",
+            orientation="h",
+            x=0.0,
+            xanchor="left",
+            y=1.2,
+            yanchor="top",
+        ),
         xaxis_title=xaxis_title,
         yaxis_title=yaxis_title,
         hovermode="x unified",
         template="plotly_white",
+    )
+    if secondary_cols:
+        default_secondary_title = secondary_y_title or ", ".join(secondary_cols)
+        yaxis2_updates: dict[str, object] = {
+            "title": default_secondary_title,
+            "anchor": "x",
+            "overlaying": "y",
+            "side": "right",
+            "showgrid": False,
+        }
+        fig.update_layout(
+            yaxis2=yaxis2_updates,
+        )
+    return fig
+
+
+# pylint: disable=too-many-statements
+def plot_time_series_battery_usecase(
+    df: pd.DataFrame,
+    time_col: str | None = None,
+    cols: list[str] | None = None,
+    title: str = "Time Series Plot",
+    xaxis_title: str = "Timestamp",
+    yaxis_title: str = "kW",
+    legend_title: str | None = "Components",
+    color_dict: dict[str, str] | None = None,
+    long_format_flag: bool = False,
+    category_col: str | None = None,
+    value_col: str | None = None,
+    fill_cols: list[str] | None = None,
+    dotted_cols: list[str] | None = None,
+    plot_order: list[str] | None = None,
+    shade_by_category: bool = False,
+    battery_power_flow: str = "battery_power_flow",
+    battery_charging: str = "battery_discharge",
+    battery_discharging: str = "battery_charge",
+    pv_col: str = "pv",
+    grid_consumption_without_battery: str = "grid_consumption_without_battery",
+    grid_consumption: str = "grid_consumption",
+    secondary_y_cols: Sequence[str] | None = None,
+    secondary_y_title: str | None = None,
+) -> go.Figure:
+    """Plot a battery-usecase time series with charge/discharge overlays.
+
+    Builds a reporting plot for battery-usecase analysis by combining the
+    standard time-series traces with dedicated filled overlays for battery
+    charging and discharging between the grid-consumption baselines.
+
+    Args:
+        df: Source DataFrame containing the battery-usecase time series.
+        time_col: Optional timestamp column to use as the x-axis.
+        cols: Optional columns to plot.
+        title: Plot title.
+        xaxis_title: X-axis label.
+        yaxis_title: Primary y-axis label.
+        legend_title: Legend title.
+        color_dict: Optional color mapping for traces.
+        long_format_flag: Whether ``df`` is in long format.
+        category_col: Category column name for long-format inputs.
+        value_col: Value column name for long-format inputs.
+        fill_cols: Columns to render as filled traces.
+        dotted_cols: Columns to render with dotted lines.
+        plot_order: Optional explicit trace order.
+        shade_by_category: Whether to generate color shades by category.
+        battery_power_flow: Column containing battery power flow values.
+        battery_charging: Column containing the battery charging series.
+        battery_discharging: Column containing the battery discharging series.
+        pv_col: Column containing PV production values.
+        grid_consumption_without_battery: Column containing grid consumption
+            without battery support.
+        grid_consumption: Column containing grid consumption with battery
+            support.
+        secondary_y_cols: Optional columns to render on the secondary y-axis.
+        secondary_y_title: Secondary y-axis label.
+
+    Returns:
+        A Plotly figure for battery-usecase analysis.
+    """
+    plot_df, cols, fill_cols, dotted_cols, plot_order, secondary_y_cols, color_dict = (
+        prepare_battery_usecase_plot(
+            df,
+            cols=cols,
+            fill_cols=fill_cols,
+            dotted_cols=dotted_cols,
+            plot_order=plot_order,
+            secondary_y_cols=secondary_y_cols,
+            color_dict=color_dict,
+            time_col=time_col,
+            battery_power_flow=battery_power_flow,
+            battery_charging=battery_charging,
+            battery_discharging=battery_discharging,
+            pv_col=pv_col,
+            grid_consumption_without_battery=grid_consumption_without_battery,
+            grid_consumption=grid_consumption,
+        )
+    )
+    fig = plot_time_series(
+        plot_df,
+        time_col=time_col,
+        cols=cols,
+        title=title,
+        xaxis_title=xaxis_title,
+        yaxis_title=yaxis_title,
+        legend_title=legend_title,
+        color_dict=color_dict,
+        long_format_flag=long_format_flag,
+        category_col=category_col,
+        value_col=value_col,
+        fill_cols=fill_cols,
+        dotted_cols=dotted_cols,
+        plot_order=plot_order,
+        shade_by_category=shade_by_category,
+        secondary_y_cols=secondary_y_cols,
+        secondary_y_title=secondary_y_title,
+    )
+    fig.update_layout(
+        legend=dict(y=1.28, yanchor="top"),
+        margin=dict(t=145),
+    )
+    source_df = plot_df if time_col is None else plot_df.set_index(time_col)
+    add_battery_usecase_overlay_traces(
+        fig,
+        source_df,
+        color_dict=color_dict,
+        yaxis_title=yaxis_title,
     )
     return fig
 

--- a/src/frequenz/lib/notebooks/reporting/utils/battery_usecase_plot.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/battery_usecase_plot.py
@@ -1,0 +1,334 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Helpers for battery-usecase plotting."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from matplotlib import colors as mcolors
+
+from frequenz.lib.notebooks.reporting.utils.colors import COLOR_DICT
+
+_DISPLAY_LABELS: dict[str, str] = {
+    "grid_consumption": "Netzbezug",
+    "grid_consumption_without_battery": "Netzbezug ohne Batterie",
+    "battery_power_flow": "Batterie Leistungsfluss",
+    "battery_discharge": "Batterie Entladung",
+    "battery_charge": "Batterie Beladung",
+    "peak_before_optimization": "Lastspitze vor optimierung",
+    "peak_after_optimization": "Lastspitze nach optimierung",
+    "pv": "PV",
+}
+
+_PEAK_COLUMNS = ["peak_before_optimization", "peak_after_optimization"]
+
+_REQUIRED_OVERLAY_COLUMNS = [
+    "grid_consumption",
+    "grid_consumption_without_battery",
+    "battery_discharge",
+    "battery_charge",
+]
+
+
+# pylint: disable=too-many-arguments, too-many-locals
+def prepare_battery_usecase_plot(
+    df: pd.DataFrame,
+    *,
+    cols: list[str] | None,
+    fill_cols: list[str] | None,
+    dotted_cols: list[str] | None,
+    plot_order: list[str] | None,
+    secondary_y_cols: Sequence[str] | None,
+    color_dict: dict[str, str] | None,
+    time_col: str | None,
+    battery_power_flow: str,
+    battery_charging: str,
+    battery_discharging: str,
+    pv_col: str,
+    grid_consumption_without_battery: str,
+    grid_consumption: str,
+) -> tuple[
+    pd.DataFrame,
+    list[str] | None,
+    list[str] | None,
+    list[str] | None,
+    list[str] | None,
+    list[str] | None,
+    dict[str, str],
+]:
+    """Normalize battery-usecase inputs, apply plot defaults, and build color map."""
+    # Build rename map: legacy display names + custom column names → canonical
+    normalize_map: dict[str, str] = {v: k for k, v in _DISPLAY_LABELS.items()}
+    normalize_map.update(
+        {
+            battery_power_flow: "battery_power_flow",
+            battery_charging: "battery_discharge",
+            battery_discharging: "battery_charge",
+            pv_col: "pv",
+            grid_consumption_without_battery: "grid_consumption_without_battery",
+            grid_consumption: "grid_consumption",
+        }
+    )
+
+    def _rename(seq: list[str] | None, mapping: dict[str, str]) -> list[str] | None:
+        return None if seq is None else [mapping.get(item, item) for item in seq]
+
+    def _ensure(seq: list[str] | None, items: list[str]) -> list[str] | None:
+        if seq is None:
+            return None
+        result = list(seq)
+        for item in items:
+            if item not in result:
+                result.append(item)
+        return result
+
+    df = df.rename(columns=normalize_map)
+    cols = _rename(cols, normalize_map)
+    fill_cols = _rename(fill_cols, normalize_map)
+    dotted_cols = _rename(dotted_cols, normalize_map)
+    plot_order = _rename(plot_order, normalize_map)
+    secondary_y_cols = _rename(
+        list(secondary_y_cols) if secondary_y_cols is not None else None, normalize_map
+    )
+
+    if "pv" in df.columns:
+        fill_cols = ["pv"] if fill_cols is None else _ensure(fill_cols, ["pv"])
+        plot_order = _ensure(plot_order, ["pv"])
+
+    peak_columns = [c for c in _PEAK_COLUMNS if c in df.columns]
+    cols = _ensure(cols, peak_columns)
+    plot_order = _ensure(plot_order, peak_columns)
+    dotted_cols = _ensure(dotted_cols, peak_columns) or peak_columns
+
+    # Localize canonical names → display labels
+    df = df.rename(columns=_DISPLAY_LABELS)
+    cols = _rename(cols, _DISPLAY_LABELS)
+    fill_cols = _rename(fill_cols, _DISPLAY_LABELS)
+    dotted_cols = _rename(dotted_cols, _DISPLAY_LABELS)
+    plot_order = _rename(plot_order, _DISPLAY_LABELS)
+    secondary_y_cols = _rename(secondary_y_cols, _DISPLAY_LABELS)
+
+    # Build color map with defaults
+    colors = dict(color_dict or {})
+    colors.setdefault(_DISPLAY_LABELS["grid_consumption"], COLOR_DICT["Netzbezug"])
+    colors.setdefault(
+        _DISPLAY_LABELS["grid_consumption_without_battery"], COLOR_DICT["Netzbezug"]
+    )
+    for peak_col in peak_columns:
+        colors.setdefault(_DISPLAY_LABELS[peak_col], COLOR_DICT["peak"])
+
+    display_pv = _DISPLAY_LABELS["pv"]
+    if display_pv in df.columns:
+        if cols is None:
+            cols = [
+                c for c in df.select_dtypes(include="number").columns if c != time_col
+            ]
+        elif display_pv not in cols:
+            cols = [*cols, display_pv]
+        colors.setdefault(display_pv, COLOR_DICT["PV"])
+
+    return df, cols, fill_cols, dotted_cols, plot_order, secondary_y_cols, colors
+
+
+# pylint: disable=too-many-locals
+def add_battery_usecase_overlay_traces(
+    fig: go.Figure,
+    source_df: pd.DataFrame,
+    *,
+    color_dict: dict[str, str],
+    yaxis_title: str,
+) -> None:
+    """Hide base battery traces and add charge/discharge filled overlay areas."""
+    # Hide base traces replaced by overlay fills
+    hidden_names = {
+        _DISPLAY_LABELS["battery_power_flow"],
+        _DISPLAY_LABELS["battery_discharge"],
+        _DISPLAY_LABELS["battery_charge"],
+        "Battery Charge",
+        "Battery Discharge",
+    }
+    for trace in fig.data:
+        if isinstance(trace, go.Scatter) and trace.name in hidden_names:
+            trace.showlegend = False
+            trace.hoverinfo = "skip"
+            trace.fill = "none"
+            trace.line = {
+                "color": "rgba(0,0,0,0)",
+                "width": 0,
+                "shape": "hv",
+            }
+
+    # Check all required columns are present before adding overlays
+    required = [_DISPLAY_LABELS[c] for c in _REQUIRED_OVERLAY_COLUMNS]
+    if not all(c in source_df.columns for c in required):
+        return
+
+    display_grid = _DISPLAY_LABELS["grid_consumption"]
+    display_grid_no_batt = _DISPLAY_LABELS["grid_consumption_without_battery"]
+    charge_name = _DISPLAY_LABELS["battery_discharge"]
+    discharge_name = _DISPLAY_LABELS["battery_charge"]
+
+    charge_color = (
+        color_dict.get(charge_name)
+        or color_dict.get("Battery Charge")
+        or COLOR_DICT["Battery Charge"]
+    )
+    discharge_color = (
+        color_dict.get(discharge_name)
+        or color_dict.get("Battery Discharge")
+        or COLOR_DICT["Battery Discharge"]
+    )
+
+    grid_with_battery = pd.to_numeric(source_df[display_grid], errors="coerce")
+    grid_without_battery = pd.to_numeric(
+        source_df[display_grid_no_batt], errors="coerce"
+    )
+    charging = pd.to_numeric(source_df[charge_name], errors="coerce")
+    discharging = pd.to_numeric(source_df[discharge_name], errors="coerce")
+
+    finite_grid = grid_with_battery.notna() & grid_without_battery.notna()
+    charge_mask = finite_grid & charging.gt(0.0).fillna(False)
+    discharge_mask = finite_grid & discharging.lt(0.0).fillna(False)
+
+    for trace in _hv_fill_traces(
+        source_df.index,
+        grid_without_battery.where(charge_mask),
+        grid_with_battery.where(charge_mask),
+        charge_mask,
+        charge_color,
+        charge_name,
+    ):
+        fig.add_trace(trace)
+
+    for trace in _hv_fill_traces(
+        source_df.index,
+        grid_with_battery.where(discharge_mask),
+        grid_without_battery.where(discharge_mask),
+        discharge_mask,
+        discharge_color,
+        discharge_name,
+    ):
+        fig.add_trace(trace)
+
+    fig.add_trace(
+        go.Scatter(
+            x=source_df.index,
+            y=grid_with_battery.where(charge_mask),
+            mode="lines",
+            line={
+                "color": "rgba(0,0,0,0)",
+                "width": 0,
+                "shape": "hv",
+            },
+            showlegend=False,
+            connectgaps=False,
+            customdata=np.column_stack([charging.to_numpy(dtype=float)]),
+            legendgroup=charge_name,
+            hovertemplate=f"<b>{charge_name}</b>: %{{customdata[0]}} {yaxis_title}<extra></extra>",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=source_df.index,
+            y=grid_with_battery.where(discharge_mask),
+            mode="lines",
+            line={
+                "color": "rgba(0,0,0,0)",
+                "width": 0,
+                "shape": "hv",
+            },
+            showlegend=False,
+            connectgaps=False,
+            customdata=np.column_stack([discharging.to_numpy(dtype=float)]),
+            legendgroup=discharge_name,
+            hovertemplate=(
+                f"<b>{discharge_name}</b>: "
+                f"%{{customdata[0]}} {yaxis_title}"
+                "<extra></extra>"
+            ),
+        )
+    )
+    fig.update_layout(
+        legend={
+            "groupclick": "togglegroup",
+        }
+    )
+
+
+def _with_alpha(color: str | None, alpha: float) -> str | None:
+    """Return color as rgba string with the given alpha, or None if invalid."""
+    if not color:
+        return None
+    try:
+        r, g, b, _ = mcolors.to_rgba(color)
+    except ValueError:
+        return None
+    return (
+        f"rgba({int(round(r*255))},{int(round(g*255))},{int(round(b*255))},{alpha:.3f})"
+    )
+
+
+# pylint: disable=too-many-locals, too-many-arguments, too-many-positional-arguments
+def _hv_fill_traces(
+    x: pd.Index,
+    base: pd.Series,
+    top: pd.Series,
+    mask: pd.Series,
+    color: str,
+    name: str,
+) -> list[go.Scatter]:
+    """Build filled step polygons for contiguous active intervals."""
+    if len(x) < 2:
+        return []
+
+    interval_mask = mask.to_numpy(dtype=bool)
+    x_values = list(x)
+    base_values = base.to_numpy(dtype=float)
+    top_values = top.to_numpy(dtype=float)
+    active_intervals = np.flatnonzero(interval_mask[:-1])
+    if len(active_intervals) == 0:
+        return []
+
+    breaks = np.where(np.diff(active_intervals) > 1)[0] + 1
+    groups = np.split(active_intervals, breaks)
+    traces: list[go.Scatter] = []
+
+    def _step_coords(
+        left_edges: list[object], right_edge: object, values: np.ndarray
+    ) -> tuple[list[object], list[float]]:
+        step_x = [left_edges[0]]
+        step_y = [float(values[0])]
+        for idx, value in enumerate(values):
+            step_x.append(right_edge if idx == len(values) - 1 else left_edges[idx + 1])
+            step_y.append(float(value))
+            if idx < len(values) - 1:
+                step_x.append(left_edges[idx + 1])
+                step_y.append(float(values[idx + 1]))
+        return step_x, step_y
+
+    for group in groups:
+        left_edges = [x_values[idx] for idx in group]
+        right_edge = x_values[group[-1] + 1]
+        top_x, top_y = _step_coords(left_edges, right_edge, top_values[group])
+        base_x, base_y = _step_coords(left_edges, right_edge, base_values[group])
+        traces.append(
+            go.Scatter(
+                x=top_x + base_x[::-1],
+                y=top_y + base_y[::-1],
+                fill="toself",
+                fillcolor=_with_alpha(color, 1) or color,
+                line={"color": color, "width": 1.5, "shape": "hv"},
+                mode="lines",
+                name=name if not traces else None,
+                showlegend=not traces,
+                hoverinfo="skip",
+                legendgroup=name,
+            )
+        )
+
+    return traces

--- a/src/frequenz/lib/notebooks/reporting/utils/colors.py
+++ b/src/frequenz/lib/notebooks/reporting/utils/colors.py
@@ -65,61 +65,15 @@ def generate_shades(base_color: str, n: int) -> list[str]:
 
 
 COLOR_DICT: dict[str, str] = {
-    # Core energy sources
     "Solar": "rgba(255,214,0,1)",
     "Wind": "rgba(0,174,239,1)",
     "BHKW": "rgba(187,187,187,1)",
-    "Fossil": "rgba(68,68,68,1)",
     "Storage": "rgba(146,219,68,1)",
-    "Electric Heat": "rgba(255,102,0,1)",
-    # Other elements
     "Load": "rgba(0,0,0,1)",
-    "Day-Ahead Preis": "rgba(0,0,0,1)",
-    "Market Prices": "rgba(0,0,0,1)",
-    # 1. Beschaffungs Notebook
     "PV Erzeugung": "rgba(255,224,51,1)",
-    "PV Überschuss": "rgba(255,243,138,1)",
-    "Wind-PPA Erzeugung": "rgba(0,174,239,1)",
-    "Wind-PPA Überschuss": "rgba(102,170,221,1)",
     "BHKW Erzeugung": "rgba(187,187,187,1)",
-    "BHKW Überschuss": "rgba(221,221,221,1)",
-    "Graustrom Terminmarkt": "rgba(68,68,68,1)",
-    "Zusätzliche Leistung (gestrichelte Linien)": "rgba(136,136,136,1)",
-    # Storage & other (charging vs. discharging)
-    "Stromspeicher-beladen": "rgba(236,0,140,1)",
     "Stromspeicher-entladen": "rgba(146,219,68,1)",
-    "Zusätzliche Leistung": "rgba(146,219,68,1)",
-    "Wärmepumpe": "rgba(255,102,0,1)",
-    "Ladepark": "rgba(0,170,0,1)",
-    # Scheduling & baselines
-    "Fahrplan": "rgba(255,249,196,1)",
-    "Hochlastzeitfenster": "rgba(255,249,196,1)",
-    # 2. Atypik Notebook
-    "SoC des Speichers": "rgba(146,219,68,1)",
-    "Reduzierte Leistung, durch Speicherentladung": "rgba(187,187,187,1)",
-    "Entladeleistung (future)": "rgba(146,219,68,1)",
-    "Beladeleistung (future)": "rgba(236,0,140,1)",
-    # 3. Ladesäulen Notebook
-    "Zusätzliche Leistung durch Ladepark": "rgba(0,170,0,1)",
-    "DA-Spot Preise": "rgba(0,0,0,1)",
-    "PV-Überschuss (future)": "rgba(255,243,138,1)",
-    # 4. BHKW Notebook
-    "BHKW-Stromerzeugung": "rgba(187,187,187,1)",
     "PV-Erzeugung": "rgba(255,224,51,1)",
-    "Grenzstrompreis": "rgba(255,102,0,1)",
-    # 5. PV Optimization Notebook
-    "Abgeregelte PV-Menge": "rgba(255,252,192,1)",
-    # 6. Heat Notebook
-    "Wärmebedarf aus fossiler Erzeugung": "rgba(68,68,68,1)",
-    "Wärme aus Netzstrom": "rgba(255,102,0,1)",
-    "Heizleistung aus Netzstrom": "rgba(255,102,0,1)",
-    "Wärmepumpe (Heat)": "rgba(255,153,51,1)",
-    "Heizstab": "rgba(255,214,153,1)",
-    "PV-Netzeinspeisung": "rgba(255,224,51,1)",
-    "Wärmebedarf aus PV-Überschuss": "rgba(255,243,138,1)",
-    "Wärmebedarf aus PV-Überschuss im Wärmespeicher": "rgba(255,252,192,1)",
-    "Wärmebedarf aus zusätzlichen Netzbezug": "rgba(255,249,196,1)",
-    # Existing reporting labels aligned to the new conventions
     "PV": "rgba(255,224,51,1)",
     "PV-Erzeugung [kWh]": "rgba(255,224,51,1)",
     "PV-Erzeugung [kWh] Sum": "rgba(255,224,51,1)",
@@ -129,24 +83,16 @@ COLOR_DICT: dict[str, str] = {
     "BHKW-Erzeugung [kWh] Sum": "rgba(187,187,187,1)",
     "Netto Gesamtverbrauch": "rgba(0,0,0,1)",
     "MID Gesamtverbrauch": "rgba(0,0,0,1)",
+    "peak": "rgba(194,181,224,1)",
     "Batterie Leistungsfluss": "rgba(146,219,68,1)",
-    "Batterie Beladung": "rgba(236,0,140,1)",
-    "Batterie Entladung": "rgba(146,219,68,1)",
-    "Battery Charge": "rgba(236,0,140,1)",
-    "Battery Discharge": "rgba(146,219,68,1)",
+    "Batterie Beladung": "rgba(146,219,68,1)",
+    "Batterie Entladung": "rgba(236,0,140,1)",
+    "Battery Charge": "rgba(146,219,68,1)",
+    "Battery Discharge": "rgba(236,0,140,1)",
     "Netzbezug": "rgba(0,0,0,1)",
+    "da_price": "rgba(31, 119, 180, 1.0)",
 }
 
 LINE_DASH_MAP: dict[str, str] = {
     "Load": "solid",
-    "Day-Ahead Preis": "dot",
-    "Market Prices": "solid",
-    "Fahrplan": "solid",
-    "Hochlastzeitfenster": "solid",
-    "SoC des Speichers": "solid",
-    "Entladeleistung (future)": "solid",
-    "Beladeleistung (future)": "solid",
-    "Zusätzliche Leistung (gestrichelte Linien)": "dash",
-    "DA-Spot Preise": "solid",
-    "Grenzstrompreis": "solid",
 }

--- a/tests/test_reporting_data_processing.py
+++ b/tests/test_reporting_data_processing.py
@@ -1,0 +1,116 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for reporting data preparation helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from frequenz.lib.notebooks.reporting.data_processing import create_battery_usecase_df
+
+
+def test_create_battery_usecase_df_builds_expected_columns() -> None:
+    """Battery usecase helper derives the expected canonical columns."""
+    energy_report_df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+        }
+    )
+    result = create_battery_usecase_df(energy_report_df)
+
+    expected = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+            "grid_consumption_without_battery": [35.0, 21.0],
+            "peak_before_optimization": [35.0, 35.0],
+            "peak_after_optimization": [30.0, 30.0],
+            "battery_discharge": [5.0, 0.0],
+            "battery_charge": [0.0, -4.0],
+        }
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_create_battery_usecase_df_preserves_pv_when_available() -> None:
+    """Optional PV production is retained in the standardized output."""
+    energy_report_df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+            "pv_asset_production": [12.0, 10.0],
+        }
+    )
+    result = create_battery_usecase_df(energy_report_df)
+
+    expected = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+            "pv": [12.0, 10.0],
+            "grid_consumption_without_battery": [35.0, 21.0],
+            "peak_before_optimization": [35.0, 35.0],
+            "peak_after_optimization": [30.0, 30.0],
+            "battery_discharge": [5.0, 0.0],
+            "battery_charge": [0.0, -4.0],
+        }
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_create_battery_usecase_df_accepts_custom_input_column_names() -> None:
+    """Custom source column names are normalized to the canonical output schema."""
+    energy_report_df = pd.DataFrame(
+        {
+            "time": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_load": [30.0, 25.0],
+            "battery_flow": [5.0, -4.0],
+            "pv_power": [12.0, 10.0],
+        }
+    )
+    result = create_battery_usecase_df(
+        energy_report_df,
+        timestamp_col="time",
+        grid_consumption_col="grid_load",
+        battery_col="battery_flow",
+        pv_col="pv_power",
+    )
+
+    expected = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+            "pv": [12.0, 10.0],
+            "grid_consumption_without_battery": [35.0, 21.0],
+            "peak_before_optimization": [35.0, 35.0],
+            "peak_after_optimization": [30.0, 30.0],
+            "battery_discharge": [5.0, 0.0],
+            "battery_charge": [0.0, -4.0],
+        }
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_create_battery_usecase_df_requires_configured_input_columns() -> None:
+    """Missing required columns should fail clearly."""
+    energy_report_df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00"]),
+            "grid_consumption": [30.0],
+        }
+    )
+
+    with pytest.raises(KeyError, match="battery_power_flow"):
+        create_battery_usecase_df(energy_report_df)

--- a/tests/test_reporting_plotter.py
+++ b/tests/test_reporting_plotter.py
@@ -1,0 +1,84 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for reporting plotting helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pandas as pd
+
+from frequenz.lib.notebooks.reporting.plotter import (  # noqa: E402
+    plot_time_series_battery_usecase,
+)
+
+gridpool = sys.modules.setdefault(
+    "frequenz.gridpool", types.ModuleType("frequenz.gridpool")
+)
+
+if not hasattr(gridpool, "MicrogridConfig"):
+    setattr(gridpool, "MicrogridConfig", object)
+
+
+def test_plot_time_series_battery_usecase_adds_peak_lines() -> None:
+    """Peak reference lines should be plotted even when omitted from cols."""
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "grid_consumption": [30.0, 25.0],
+            "battery_power_flow": [5.0, -4.0],
+            "grid_consumption_without_battery": [35.0, 21.0],
+            "peak_before_optimization": [35.0, 35.0],
+            "peak_after_optimization": [30.0, 30.0],
+            "battery_discharge": [5.0, 0.0],
+            "battery_charge": [0.0, -4.0],
+            "pv": [12.0, 10.0],
+        }
+    )
+
+    fig = plot_time_series_battery_usecase(
+        df,
+        time_col="timestamp",
+        cols=[
+            "grid_consumption",
+            "grid_consumption_without_battery",
+            "battery_discharge",
+            "battery_charge",
+            "pv",
+        ],
+    )
+
+    traces_by_name = {
+        trace.name: trace for trace in fig.data if getattr(trace, "name", None)
+    }
+
+    assert "Lastspitze vor optimierung" in traces_by_name
+    assert "Lastspitze nach optimierung" in traces_by_name
+    assert traces_by_name["Lastspitze vor optimierung"].line.dash == "dot"
+    assert traces_by_name["Lastspitze nach optimierung"].line.dash == "dot"
+
+
+def test_plot_time_series_battery_usecase_accepts_legacy_german_columns() -> None:
+    """Legacy German column names should still render through the adapter layer."""
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2026-01-09 06:30:00", "2026-01-09 07:00:00"]),
+            "Netzbezug": [30.0, 25.0],
+            "Batterie Leistungsfluss": [5.0, -4.0],
+            "Netzbezug ohne Batterie": [35.0, 21.0],
+            "Lastspitze vor optimierung": [35.0, 35.0],
+            "Lastspitze nach optimierung": [30.0, 30.0],
+            "Batterie Entladung": [5.0, 0.0],
+            "Batterie Beladung": [0.0, -4.0],
+            "PV": [12.0, 10.0],
+        }
+    )
+
+    fig = plot_time_series_battery_usecase(df, time_col="timestamp")
+    trace_names = [trace.name for trace in fig.data if getattr(trace, "name", None)]
+
+    assert "Netzbezug" in trace_names
+    assert "Lastspitze vor optimierung" in trace_names
+    assert "Lastspitze nach optimierung" in trace_names


### PR DESCRIPTION
This PR adds a dedicated reporting battery-usecase plot together with a standardized `create_battery_usecase_df()` helper to prepare the required input data. It also updates the battery usecase workflow to use German reporting labels, support optional PV area fills, and improve battery charge/discharge fill rendering and shared color handling.

This is how the battery usecase looks currently:

<img width="950" height="700" alt="newplot (9)" src="https://github.com/user-attachments/assets/d4278ba7-4654-40d8-96a0-581e060db992" />
