### PR TITLE
Add day ahead prices

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 - Adding wind data to data fetching.
+- Add day ahead prices fetching.
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "types-pyyaml>=6.0.12.20250915",
   "marshmallow>=4.1.0,<5",
   "pyyaml>=6.0.3",
+  "entsoe-py>=0.8.0",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/lib/notebooks/dayahead.py
+++ b/src/frequenz/lib/notebooks/dayahead.py
@@ -1,0 +1,98 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Functions for CLI tool to interact with the day-ahead pricing API."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pandas as pd
+from entsoe import EntsoePandasClient  # type: ignore[attr-defined]
+
+
+def _normalize_prices(
+    prices: pd.Series | pd.DataFrame,
+) -> pd.Series:
+    """Normalize ENTSO-E day-ahead prices into a single named series.
+
+    Args:
+        prices: The raw response from `query_day_ahead_prices()`.
+
+    Returns:
+        A series named ``price`` with index name ``timestamp``.
+
+    Raises:
+        ValueError: If the response is a dataframe with more than one column.
+        TypeError: If the response type is unsupported.
+    """
+    if isinstance(prices, pd.DataFrame):
+        if prices.shape[1] != 1:
+            raise ValueError(
+                "Expected a single price series from ENTSO-E, "
+                f"got {prices.shape[1]} columns."
+            )
+        prices = prices.iloc[:, 0]
+    elif not isinstance(prices, pd.Series):
+        raise TypeError(
+            "Expected ENTSO-E day-ahead prices as a pandas Series or "
+            f"single-column DataFrame, got {type(prices).__name__}."
+        )
+
+    prices = prices.copy()
+    prices.name = "price"
+    prices.index.name = "timestamp"
+    return prices
+
+
+def fetch_day_ahead_prices(
+    entsoe_key: str | None,
+    start: datetime,
+    end: datetime,
+    country_code: str,
+) -> pd.Series:
+    """Fetch day-ahead prices for a given country code as a normalized series.
+
+    Args:
+        entsoe_key: The API key for the Entsoe API. If not provided, the value
+            is read from the ``ENTSOE_API_KEY`` environment variable.
+        start: The start date of the query.
+        end: The end date of the query.
+        country_code: The country code for which to query the prices.
+
+    Returns:
+        A pandas series named ``price`` indexed by timestamp.
+
+    Raises:
+        ModuleNotFoundError: If the optional entsoe dependency is not installed.
+        ValueError: If the time window is invalid or no API key is available.
+    """
+    if EntsoePandasClient is None:
+        raise ModuleNotFoundError(
+            "The optional dependency 'entsoe-py' is required to fetch day-ahead "
+            "prices. Install it before calling fetch_day_ahead_prices()."
+        )
+
+    api_key = entsoe_key or os.getenv("ENTSOE_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "Missing ENTSO-E API key. Pass entsoe_key explicitly or set the "
+            "ENTSOE_API_KEY environment variable."
+        )
+
+    if start >= end:
+        raise ValueError(
+            f"Expected start to be earlier than end, got start={start!r}, end={end!r}."
+        )
+
+    start_ts = pd.Timestamp(start)
+    end_ts = pd.Timestamp(end)
+
+    if start_ts.tzinfo is None or end_ts.tzinfo is None:
+        raise ValueError("Please use timezone-aware datetimes for start and end.")
+
+    client = EntsoePandasClient(api_key=api_key)
+    return _normalize_prices(
+        client.query_day_ahead_prices(country_code, start=start_ts, end=end_ts)
+    )

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
@@ -13,8 +13,26 @@ from dotenv import load_dotenv
 from frequenz.gridpool import MicrogridConfig
 
 from frequenz.data.microgrid import MicrogridData
+from frequenz.lib.notebooks.dayahead import fetch_day_ahead_prices
 
 _logger = logging.getLogger(__name__)
+
+
+def _align_series_to_index(index: pd.Index, series: pd.Series) -> pd.Series:
+    """Align a time series to a target datetime index using forward fill."""
+    target_index = pd.DatetimeIndex(index)
+    aligned = series.copy()
+    aligned.index = pd.DatetimeIndex(aligned.index)
+
+    if target_index.tz is not None and aligned.index.tz is None:
+        aligned.index = aligned.index.tz_localize(target_index.tz)
+    elif target_index.tz is None and aligned.index.tz is not None:
+        aligned.index = aligned.index.tz_convert("UTC").tz_localize(None)
+    elif target_index.tz is not None and aligned.index.tz is not None:
+        aligned.index = aligned.index.tz_convert(target_index.tz)
+
+    aligned = aligned.sort_index()
+    return aligned.reindex(target_index, method="ffill")
 
 
 async def init_microgrid_data(
@@ -74,6 +92,50 @@ async def init_microgrid_data(
         sign_secret=api_secret,
         microgrid_configs=mcfg,
     )
+
+
+def merge_day_ahead_prices(
+    df: pd.DataFrame,
+    *,
+    dayahead_api_key: str | None = None,
+    dayahead_country_code: str,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+) -> pd.DataFrame:
+    """Merge ENTSO-E day-ahead prices into an existing battery-usecase dataframe.
+
+    Args:
+        df: Base dataframe to enrich with day-ahead prices.
+        dayahead_api_key: ENTSO-E API key. If not provided, the value is read
+            from the ``ENTSOE_API_KEY`` environment variable.
+        dayahead_country_code: ENTSO-E country code.
+        start_time: Optional explicit start time for the day-ahead query.
+        end_time: Optional explicit end time for the day-ahead query.
+
+    Returns:
+        A copy of ``df`` with a ``day_ahead_price`` column aligned to the dataframe
+        index.
+    """
+    if df.empty:
+        return df.copy()
+
+    start = start_time or pd.Timestamp(df.index.min()).to_pydatetime()
+    end = end_time or pd.Timestamp(df.index.max()).to_pydatetime()
+
+    if start_time is None and len(df.index) > 1:
+        resolution = pd.Timestamp(df.index[1]) - pd.Timestamp(df.index[0])
+        end = (pd.Timestamp(df.index.max()) + resolution).to_pydatetime()
+
+    da_prices = fetch_day_ahead_prices(
+        entsoe_key=dayahead_api_key,
+        start=start,
+        end=end,
+        country_code=dayahead_country_code,
+    )
+
+    merged = df.copy()
+    merged["day_ahead_price"] = _align_series_to_index(merged.index, da_prices)
+    return merged
 
 
 # pylint: disable=too-many-arguments

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_data.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_data.py
@@ -47,6 +47,7 @@ class BatteryPowerData:
     battery: pd.Series
     charge: pd.Series
     discharge: pd.Series
+    day_ahead_price: pd.Series | None
     max_abs_battery: float
 
 
@@ -227,6 +228,7 @@ def prepare_battery_power_data(df: pd.DataFrame) -> BatteryPowerData:
 
     charge = _masked(df["battery"], df["battery"] > 0)
     discharge = _masked(df["battery"], df["battery"] <= 0)
+    day_ahead_price = df["day_ahead_price"] if "day_ahead_price" in df.columns else None
 
     return BatteryPowerData(
         index=df.index,
@@ -235,6 +237,7 @@ def prepare_battery_power_data(df: pd.DataFrame) -> BatteryPowerData:
         battery=df["battery"],
         charge=charge,
         discharge=discharge,
+        day_ahead_price=day_ahead_price,
         max_abs_battery=max_abs_bat,
     )
 

--- a/tests/test_dayahead.py
+++ b/tests/test_dayahead.py
@@ -1,0 +1,88 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for day-ahead helpers."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from frequenz.lib.notebooks.dayahead import (
+    fetch_day_ahead_prices,
+)
+
+
+def test_fetch_day_ahead_prices_returns_normalized_series(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that day-ahead prices are returned as a normalized series."""
+    prices = pd.Series(
+        [42.0, 43.5],
+        index=pd.to_datetime(["2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"]),
+    )
+    client = MagicMock()
+    client.query_day_ahead_prices.return_value = prices
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        "frequenz.lib.notebooks.dayahead.EntsoePandasClient", client_factory
+    )
+
+    result = fetch_day_ahead_prices(
+        entsoe_key="test-key",
+        start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        end=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
+        country_code="DE_LU",
+    )
+
+    assert result.name == "price"
+    assert result.index.name == "timestamp"
+    assert result.tolist() == [42.0, 43.5]
+
+
+def test_fetch_day_ahead_prices_uses_environment_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that the ENTSO-E API key can be read from the environment."""
+    prices = pd.Series(
+        [42.0, 43.5],
+        index=pd.to_datetime(["2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"]),
+    )
+    client = MagicMock()
+    client.query_day_ahead_prices.return_value = prices
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        "frequenz.lib.notebooks.dayahead.EntsoePandasClient", client_factory
+    )
+    monkeypatch.setenv("ENTSOE_API_KEY", "env-test-key")
+
+    fetch_day_ahead_prices(
+        entsoe_key=None,
+        start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        end=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
+        country_code="DE_LU",
+    )
+
+    client_factory.assert_called_once_with(api_key="env-test-key")
+
+
+def test_fetch_day_ahead_prices_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a clear error is raised when no API key is available."""
+    client_factory = MagicMock()
+    monkeypatch.setattr(
+        "frequenz.lib.notebooks.dayahead.EntsoePandasClient", client_factory
+    )
+    monkeypatch.delenv("ENTSOE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ENTSOE_API_KEY"):
+        fetch_day_ahead_prices(
+            entsoe_key=None,
+            start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            end=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
+            country_code="DE_LU",
+        )
+
+    client_factory.assert_not_called()


### PR DESCRIPTION
This PR adds ENTSO-E day-ahead price support via a new dayahead.py helper, including API-key validation, timezone/window checks, and CSV output for fetched prices.