### PR TITLE
Add PSC power plot and multi-file dotenv support for asset optimization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,13 +6,17 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `init_microgrid_data` reads credentials from `API_AUTH_KEY`/`API_SIGN_SECRET`, falling back to `API_KEY`/`API_SECRET`. Both halves must come from the same pair.
+- Dotenv files passed to `init_microgrid_data` now override the environment and each other, so pass the most specific file last.
 
 ## New Features
 
 - Adding wind data to data fetching.
 - Add day ahead prices fetching.
+- Add `plot_power` to the asset optimization plotly visualizations, stacking each component in the passive sign convention so the top of the stack meets the grid line. Unlike `plot_power_flow`, production is not clipped.
+- `init_microgrid_data` accepts several dotenv files, so shared API URLs can live apart from per-microgrid credentials.
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- `init_microgrid_data` no longer reuses the credentials of a previously loaded dotenv file, which made switching microgrid in a running notebook kernel keep the first microgrid's key.
+- `~` in a dotenv path is expanded instead of silently loading nothing.

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/data.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -35,28 +36,68 @@ def _align_series_to_index(index: pd.Index, series: pd.Series) -> pd.Series:
     return aligned.reindex(target_index, method="ffill")
 
 
+def _load_dotenv_files(dotenv_path: str | Sequence[str]) -> None:
+    """Load dotenv files in order, later files overriding earlier ones.
+
+    Overriding matters in notebooks: without it a variable loaded for one microgrid
+    survives in the kernel and shadows the file loaded for the next one.
+    """
+    paths = [dotenv_path] if isinstance(dotenv_path, str) else dotenv_path
+    for path in paths:
+        # load_dotenv hands the path to open(), which does not expand "~".
+        expanded = os.path.expanduser(path)
+        if not load_dotenv(dotenv_path=expanded, override=True):
+            _logger.warning("No environment variables loaded from %s.", expanded)
+
+
+_CREDENTIAL_ENV_PAIRS = (
+    ("API_AUTH_KEY", "API_SIGN_SECRET"),
+    ("API_KEY", "API_SECRET"),
+)
+
+
+def _credentials() -> tuple[str, str]:
+    """Return the first credential pair whose key and secret are both set.
+
+    Both halves must come from the same pair, otherwise a key from one dotenv file
+    could end up signed with a secret from another.
+    """
+    for key_var, secret_var in _CREDENTIAL_ENV_PAIRS:
+        key = os.getenv(key_var, "")
+        secret = os.getenv(secret_var, "")
+        if key and secret:
+            return key, secret
+
+    names = " or ".join(f"{k}/{s}" for k, s in _CREDENTIAL_ENV_PAIRS)
+    _logger.warning(
+        "No credentials found (%s). Requests will be unauthenticated.", names
+    )
+    return "", ""
+
+
 async def init_microgrid_data(
     *,
     microgrid_config_file: str | None = None,
     microgrid_config_dir: str | None = None,
-    dotenv_path: str | None = None,
+    dotenv_path: str | Sequence[str] | None = None,
 ) -> MicrogridData:
     """Load MicrogridData instance using environment variables.
 
     Args:
         microgrid_config_file: Path to a microgrid configuration file.
         microgrid_config_dir: Directory containing microgrid configuration files.
-        dotenv_path: Optional path to an environment variable file.
+        dotenv_path: Optional path, or paths, to environment variable files. They
+            are loaded in order and override both earlier files and the current
+            environment, so list the most specific file last.
 
     Returns:
         MicrogridData instance.
     """
     if dotenv_path is not None:
-        load_dotenv(dotenv_path=dotenv_path)
+        _load_dotenv_files(dotenv_path)
 
     service_address = os.environ["REPORTING_API_URL"]
-    api_key = os.getenv("API_KEY", "")
-    api_secret = os.getenv("API_SECRET", "")
+    api_key, api_secret = _credentials()
 
     assets_url = os.environ.get("ASSETS_API_URL")
     if not assets_url:

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_colors.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_colors.py
@@ -5,6 +5,7 @@
 
 CHP = "rgba(100, 149, 237, 1)"
 PV = "rgba(255, 243, 138, 1)"
+WIND = "rgba(0, 176, 185, 1)"
 CONSUMPTION = "rgba(0, 0, 0, 1)"
 GRID = "rgba(128, 128, 128, 1)"
 CHARGE = "rgba(236, 0, 140, 0.45)"
@@ -15,3 +16,15 @@ SOC = "rgba(0, 204, 150, 1)"
 AVAILABLE = "rgba(0, 0, 0, 1)"
 ZERO_LINE = "rgba(128, 128, 128, 1)"
 TRANSPARENT = "rgba(0,0,0,0)"
+
+# Palette for the cumulative PSC stack plot. Alpha is baked in: the bands overlap
+# and cross zero, so they must read through each other. Charge/discharge use the
+# green/red convention of the original plot, which inverts the hues above.
+STACK_CHP = "rgba(100, 149, 237, 0.35)"
+STACK_PV = "rgba(255, 215, 0, 0.40)"
+STACK_WIND = "rgba(0, 176, 185, 0.40)"
+STACK_CHARGE = "rgba(0, 128, 0, 0.30)"
+STACK_DISCHARGE = "rgba(220, 20, 60, 0.40)"
+STACK_GRID = "rgba(0, 0, 0, 1)"
+STACK_CONSUMPTION = "rgba(128, 128, 128, 1)"
+STACK_LINE_WIDTH = 2

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_data.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_data.py
@@ -29,6 +29,27 @@ class PowerFlowData:
 
 
 @dataclass(frozen=True)
+class PowerData:
+    """Cumulative PSC levels for the stacked power plot.
+
+    Each level is the running sum of the preceding one plus the next component,
+    so after_battery coincides with grid by energy balance.
+    """
+
+    index: pd.Index
+    consumption: pd.Series
+    after_chp: pd.Series
+    after_pv: pd.Series
+    after_wind: pd.Series
+    after_battery: pd.Series
+    grid: pd.Series
+    has_chp: bool
+    has_pv: bool
+    has_wind: bool
+    has_battery: bool
+
+
+@dataclass(frozen=True)
 class EnergyTradeData:
     """Prepared series for energy trade plotting."""
 
@@ -143,6 +164,52 @@ def prepare_power_flow_data(df: pd.DataFrame) -> PowerFlowData:
         charge=charge,
         discharge=discharge,
         grid=grid,
+    )
+
+
+def prepare_power_data(df: pd.DataFrame) -> PowerData:
+    """Prepare cumulative PSC levels for the stacked power plot.
+
+    Unlike prepare_power_flow_data, signs are left in the raw PSC convention
+    (consumption positive, production negative) and production is not clipped, so
+    the running sum closes on the grid series:
+
+        consumption + chp + pv + wind + battery == grid
+
+    Args:
+        df:
+            Input DataFrame containing at least the consumption and grid columns.
+            chp, pv, wind and battery are used if present.
+
+    Returns:
+        A structured container with the consumption baseline, one cumulative level
+        per component, the grid series, and flags for the components present.
+    """
+    require_columns(df, "consumption", "grid")
+
+    def _column(name: str) -> pd.Series:
+        if name in df.columns:
+            return df[name]
+        return pd.Series(0.0, index=df.index)
+
+    cons = df["consumption"]
+    after_chp = cons + _column("chp")
+    after_pv = after_chp + _column("pv")
+    after_wind = after_pv + _column("wind")
+    after_battery = after_wind + _column("battery")
+
+    return PowerData(
+        index=df.index,
+        consumption=cons,
+        after_chp=after_chp,
+        after_pv=after_pv,
+        after_wind=after_wind,
+        after_battery=after_battery,
+        grid=df["grid"],
+        has_chp="chp" in df.columns,
+        has_pv="pv" in df.columns,
+        has_wind="wind" in df.columns,
+        has_battery="battery" in df.columns,
     )
 
 

--- a/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_plotly.py
+++ b/src/frequenz/lib/notebooks/reporting/asset_optimization/viz_plotly.py
@@ -21,12 +21,21 @@ from .viz_colors import (
     PV,
     SELL,
     SOC,
+    STACK_CHARGE,
+    STACK_CHP,
+    STACK_CONSUMPTION,
+    STACK_DISCHARGE,
+    STACK_GRID,
+    STACK_LINE_WIDTH,
+    STACK_PV,
+    STACK_WIND,
     ZERO_LINE,
 )
 from .viz_data import (
     prepare_battery_power_data,
     prepare_energy_trade_data,
     prepare_monthly_data,
+    prepare_power_data,
     prepare_power_flow_data,
 )
 
@@ -38,6 +47,7 @@ LINE_WIDTH = 1
 FONT_SIZE = 14
 FONT_FAMILY = "Golos Text, sans-serif"
 GRID_LINE_WIDTH = 1
+ZERO_LINE_WIDTH = 2
 HOVER_BG = "rgba(255,255,255,0.95)"
 HOVER_BORDER = "rgba(0,0,0,0.2)"
 HOVER_FONT_COLOR = "#111"
@@ -399,6 +409,239 @@ def plot_power_flow(
         ],
         row=row,
     )
+    return fig
+
+
+def _split_segments(mask: np.ndarray) -> list[tuple[int, int]]:
+    """Return [(start, end), …] for each contiguous True-run in *mask*."""
+    if not mask.any():
+        return []
+    diff = np.diff(mask.astype(int))
+    starts = np.where(diff == 1)[0] + 1
+    ends = np.where(diff == -1)[0]
+    if mask[0]:
+        starts = np.r_[0, starts]
+    if mask[-1]:
+        ends = np.r_[ends, mask.size - 1]
+    return list(zip(starts, ends))
+
+
+def _step_x(x: np.ndarray, start: int, end: int) -> np.ndarray:
+    """Return the doubled x coordinates spanning the hv steps of samples start..end.
+
+    Sample i holds from x[i] to x[i+1], so the run reaches one sample past its last
+    index. A run ending on the final sample is extended by the sampling interval,
+    which is the only width it can be given. Without this a single-sample run would
+    collapse to zero width and disappear.
+    """
+    if end + 1 < x.size:
+        right = x[end + 1]
+    else:
+        right = x[end] + (x[end] - x[end - 1]) if x.size > 1 else x[end]
+    edges = np.concatenate([x[start : end + 1], [right]])
+    return np.repeat(edges, 2)[1:-1]
+
+
+# pylint: disable=too-many-arguments
+def _add_step_fill(
+    fig: go.Figure,
+    *,
+    x_index: pd.Index,
+    upper: np.ndarray,
+    lower: np.ndarray,
+    segments: list[tuple[int, int]],
+    color: str,
+    name: str,
+) -> None:
+    """Fill between two step curves over each segment, with one legend entry."""
+    x = x_index.to_numpy()
+    for start, end in segments:
+        x_step = _step_x(x, start, end)
+        # slice incl. endpoint
+        y_up = np.repeat(upper[start : end + 1], 2)
+        y_lo = np.repeat(lower[start : end + 1], 2)
+
+        # closed polygon
+        fig.add_trace(
+            go.Scatter(
+                x=np.concatenate([x_step, x_step[::-1]]),
+                y=np.concatenate([y_up, y_lo[::-1]]),
+                mode="lines",
+                line={"width": 0},
+                fill="toself",
+                fillcolor=color,
+                hoverinfo="skip",
+                showlegend=False,
+            )
+        )
+
+    # legend proxy
+    fig.add_trace(
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="markers",
+            marker={"size": 10, "color": color},
+            name=name,
+            hoverinfo="skip",
+        )
+    )
+
+
+def _restore_stack_line_widths(traces: tuple[go.Scatter, ...]) -> None:
+    """Re-assert the line widths the stack relies on.
+
+    _apply_common_layout stamps LINE_WIDTH on every scatter, which would outline
+    the fills and reveal the invisible baseline.
+    """
+    for trace in traces:
+        if trace.fill in ("tonexty", "toself"):
+            trace.line.width = 0
+        elif trace.name in ("Grid", "Consumption"):
+            trace.line.width = STACK_LINE_WIDTH
+    traces[0].line.width = 0
+
+
+def plot_power(
+    df: pd.DataFrame,
+    fig: go.Figure | None = None,
+    row: int | None = None,
+) -> go.Figure:
+    """Plot the microgrid power as a cumulative PSC stack.
+
+    Each component is added to the running total in its raw PSC sign, starting
+    from the consumption line, so the top of the stack coincides with the grid
+    line by energy balance. A stack top that drifts away from the grid line means
+    the components do not account for the measured exchange.
+
+    Unlike plot_power_flow, production is not clipped, so PV drawing power is
+    visible rather than silently flattened to zero.
+
+    Args:
+        df: Input DataFrame containing the columns required by prepare_power_data.
+        fig: Optional existing figure to add traces to. If not provided, a new
+            figure is created.
+        row: Optional subplot row index. When provided, common layout and range
+            slider configuration are skipped and axis padding is applied to the
+            specified subplot row.
+
+    Returns:
+        A Plotly figure containing the stacked power traces.
+    """
+    data = prepare_power_data(df)
+
+    if fig is None:
+        fig = go.Figure()
+
+    legend_items = 0
+    first_trace = len(fig.data)
+
+    # Invisible consumption baseline so the first band fills from the cons line.
+    fig.add_trace(
+        go.Scatter(
+            x=data.index,
+            y=data.consumption,
+            mode="lines",
+            line={"width": 0, "shape": "hv"},
+            hoverinfo="skip",
+            showlegend=False,
+        )
+    )
+
+    bands = (
+        (data.has_chp, data.after_chp, "CHP", STACK_CHP),
+        (data.has_pv, data.after_pv, "PV", STACK_PV),
+        (data.has_wind, data.after_wind, "Wind", STACK_WIND),
+    )
+    for present, level, name, color in bands:
+        if not present:
+            continue
+        fig.add_trace(
+            go.Scatter(
+                x=data.index,
+                y=level,
+                name=name,
+                mode="lines",
+                line={"width": 0, "shape": "hv"},
+                fill="tonexty",
+                fillcolor=color,
+                hovertemplate=f"<b>{name}</b>: %{{y}} kW<extra></extra>",
+            )
+        )
+        legend_items += 1
+
+    if data.has_battery:
+        top = data.after_battery.to_numpy()
+        base = data.after_wind.to_numpy()
+        _add_step_fill(
+            fig,
+            x_index=data.index,
+            upper=top,
+            lower=base,
+            segments=_split_segments(top > base),
+            color=STACK_CHARGE,
+            name="Charge",
+        )
+        _add_step_fill(
+            fig,
+            x_index=data.index,
+            upper=base,
+            lower=top,
+            segments=_split_segments(top < base),
+            color=STACK_DISCHARGE,
+            name="Discharge",
+        )
+        legend_items += 2
+
+    # Grid line on top, should visually coincide with the stack top.
+    fig.add_trace(
+        go.Scatter(
+            x=data.index,
+            y=data.grid,
+            name="Grid",
+            line={"color": STACK_GRID, "shape": "hv", "width": STACK_LINE_WIDTH},
+            hovertemplate="<b>Grid</b>: %{y} kW<extra></extra>",
+        )
+    )
+    legend_items += 1
+
+    fig.add_trace(
+        go.Scatter(
+            x=data.index,
+            y=data.consumption,
+            name="Consumption",
+            line={"color": STACK_CONSUMPTION, "shape": "hv", "width": STACK_LINE_WIDTH},
+            hovertemplate="<b>Consumption</b>: %{y} kW<extra></extra>",
+        )
+    )
+    legend_items += 1
+
+    _finalize_time_series_plot(
+        fig,
+        title="Power",
+        y_title="Power (kW)",
+        legend_items=legend_items,
+        x_index=data.index,
+        y_series=[
+            data.consumption,
+            data.after_chp,
+            data.after_pv,
+            data.after_wind,
+            data.after_battery,
+            data.grid,
+        ],
+        row=row,
+    )
+
+    # Zero
+    fig.update_yaxes(
+        zeroline=True,
+        zerolinecolor=ZERO_LINE,
+        zerolinewidth=ZERO_LINE_WIDTH,
+        row=row,
+        col=1 if row is not None else None,
+    )
+    _restore_stack_line_widths(fig.data[first_trace:])
     return fig
 
 


### PR DESCRIPTION
This adds a new power plot function with power contributions stacked in passive sign convention. 

Also adds support for multiple dotenv files, `dotenv_path` takes a sequence to allow multiple env files which can override each other. Also multiple credential env names are supported and paths expanded.

